### PR TITLE
Adds Traversal Middleware

### DIFF
--- a/lib/guard.ts
+++ b/lib/guard.ts
@@ -1,5 +1,6 @@
 /**
- * Guards are simple services that can protect routes from being traversed.
+ * Guards are simple services that can protect routes from being traversed. They
+ * are implemented using traversal middleware
  *
  * A guard is called when the router begins traversing a route configuration file.
  * It returns `true` or `false` to let the router know if it should consider
@@ -17,6 +18,8 @@ import { provide, Provider, OpaqueToken, Injector } from 'angular2/core';
 
 import { createFactoryProvider } from './util';
 import { Route } from './route';
+import { useTraversalMiddleware } from './match-route';
+import { createMiddleware } from './middleware';
 
 export interface Guard {
   (): Observable<boolean>;
@@ -24,16 +27,22 @@ export interface Guard {
 
 export const createGuard = createFactoryProvider<Guard>('@ngrx/router Guard');
 
+const guardMiddleware = createMiddleware(function(injector: Injector) {
+  return (route$: Observable<Route>) => route$
+    .mergeMap(route => {
+      if( !!route.guards ) {
+        const resolved: Guard[] = route.guards.map(provider =>
+          injector.resolveAndInstantiate(provider));
 
-export function runGuards(injector: Injector, route: Route): Observable<boolean> {
-  if( !!route.guards ) {
-    const resolved: Guard[] = route.guards.map(provider =>
-      injector.resolveAndInstantiate(provider));
+        return Observable
+          .forkJoin<boolean[]>(...resolved.map(guard => guard()))
+          .map(values => values.every(value => value));
+      }
 
-    return Observable
-      .forkJoin<boolean[]>(...resolved.map(guard => guard()))
-      .map(values => values.every(value => value));
-  }
+      return Observable.of(true);
+    });
+}, [ Injector ]);
 
-  return Observable.of(true);
-}
+export const GUARD_PROVIDERS = [
+  useTraversalMiddleware(guardMiddleware)
+];

--- a/lib/guard.ts
+++ b/lib/guard.ts
@@ -11,7 +11,7 @@
  * For more powerful injection, consider looking at render middleware
  */
 import 'rxjs/add/operator/every';
-import 'rxjs/add/observable/forkJoin';
+import 'rxjs/add/observable/merge';
 import 'rxjs/add/observable/of';
 import { Observable } from 'rxjs/Observable';
 import { provide, Provider, OpaqueToken, Injector } from 'angular2/core';
@@ -35,8 +35,8 @@ const guardMiddleware = createMiddleware(function(injector: Injector) {
           injector.resolveAndInstantiate(provider));
 
         return Observable
-          .forkJoin<boolean[]>(...resolved.map(guard => guard()))
-          .map(values => values.every(value => value));
+          .merge<boolean>(...resolved.map(guard => guard()))
+          .every(signal => signal);
       }
 
       return Observable.of(true);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -7,6 +7,8 @@ import { ROUTE_SET_PROVIDERS } from './route-set';
 import { ROUTE_VIEW_PROVIDERS } from './route-view';
 import { REDIRECT_PROVIDERS } from './redirect';
 import { ROUTES, Routes } from './route';
+import { GUARD_PROVIDERS } from './guard';
+import { MATCH_ROUTE_PROVIDERS } from './match-route';
 
 export function provideRouter(routes: Routes) {
   return [
@@ -16,7 +18,9 @@ export function provideRouter(routes: Routes) {
     ROUTE_PARAMS_PROVIDERS,
     ROUTE_SET_PROVIDERS,
     ROUTE_VIEW_PROVIDERS,
-    REDIRECT_PROVIDERS
+    REDIRECT_PROVIDERS,
+    GUARD_PROVIDERS,
+    MATCH_ROUTE_PROVIDERS
   ];
 }
 
@@ -28,3 +32,4 @@ export { RouteParams } from './route-params';
 export { useLocationMiddleware, useRouteSetMiddleware, RouteSet, NextRoute } from './route-set';
 export { useRenderMiddleware, RenderInstruction } from './route-view';
 export { Routes, Route, IndexRoute } from './route';
+export { useTraversalMiddleware } from './match-route';

--- a/lib/match-pattern.ts
+++ b/lib/match-pattern.ts
@@ -1,8 +1,12 @@
 /**
- * This is a straight up copy of react-router's PatternUtils. It may be worth
- * investigating if the react-router team is open to splitting this out
- * into a separate package
- */
+* This is a straight up copy of react-router's PatternUtils. It may be worth
+* investigating if the react-router team is open to splitting this out
+* into a separate package
+*/
+
+export interface Params {
+  [param: string]: string | string[];
+}
 
 function escapeRegExp(string) {
   return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
@@ -12,39 +16,52 @@ function escapeSource(string) {
   return escapeRegExp(string).replace(/\/+/g, '/+')
 }
 
-function _compilePattern(pattern) {
-  let regexpSource = ''
-  const paramNames = []
-  const tokens = []
+export interface CompiledPattern {
+  pattern: string;
+  regexpSource: string;
+  paramNames: string[];
+  tokens: string[];
+}
 
-  let match, lastIndex = 0, matcher = /:([a-zA-Z_$][a-zA-Z0-9_$]*)|\*\*|\*|\(|\)/g
+function _compilePattern(pattern: string): CompiledPattern {
+  let regexpSource = '';
+  const paramNames: string[] = [];
+  const tokens: string[] = [];
+
+  let match: RegExpExecArray;
+  let lastIndex = 0;
+  const matcher = /:([a-zA-Z_$][a-zA-Z0-9_$]*)|\*\*|\*|\(|\)/g;
+
   while ((match = matcher.exec(pattern))) {
     if (match.index !== lastIndex) {
-      tokens.push(pattern.slice(lastIndex, match.index))
-      regexpSource += escapeSource(pattern.slice(lastIndex, match.index))
+      tokens.push(pattern.slice(lastIndex, match.index));
+      regexpSource += escapeSource(pattern.slice(lastIndex, match.index));
     }
 
-    if (match[1]) {
-      regexpSource += '([^/]+)'
-      paramNames.push(match[1])
-    } else if (match[0] === '**') {
-      regexpSource += '(.*)'
-      paramNames.push('splat')
-    } else if (match[0] === '*') {
-      regexpSource += '(.*?)'
-      paramNames.push('splat')
-    } else if (match[0] === '(') {
-      regexpSource += '(?:'
-    } else if (match[0] === ')') {
-      regexpSource += ')?'
+    if( match[1] ) {
+      regexpSource += '([^/]+)';
+      paramNames.push(match[1]);
+    }
+    else if( match[0] === '**' ) {
+      regexpSource += '(.*)';
+      paramNames.push('splat');
+    }
+    else if( match[0] === '*' ) {
+      regexpSource += '(.*?)';
+      paramNames.push('splat');
+    }
+    else if( match[0] === '(' ) {
+      regexpSource += '(?:';
+    }
+    else if( match[0] === ')' ) {
+      regexpSource += ')?';
     }
 
-    tokens.push(match[0])
-
-    lastIndex = matcher.lastIndex
+    tokens.push(match[0]);
+    lastIndex = matcher.lastIndex;
   }
 
-  if (lastIndex !== pattern.length) {
+  if( lastIndex !== pattern.length ) {
     tokens.push(pattern.slice(lastIndex, pattern.length))
     regexpSource += escapeSource(pattern.slice(lastIndex, pattern.length))
   }
@@ -54,66 +71,70 @@ function _compilePattern(pattern) {
     regexpSource,
     paramNames,
     tokens
-  }
+  };
 }
 
-const CompiledPatternsCache = {}
+const CompiledPatternsCache: { [pattern: string]: CompiledPattern } = {}
 
 export function compilePattern(pattern) {
-  if (!(pattern in CompiledPatternsCache))
-    CompiledPatternsCache[pattern] = _compilePattern(pattern)
+  if( !(pattern in CompiledPatternsCache) ) {
+    CompiledPatternsCache[pattern] = _compilePattern(pattern);
+  }
 
-  return CompiledPatternsCache[pattern]
+
+  return CompiledPatternsCache[pattern];
 }
 
 /**
- * Attempts to match a pattern on the given pathname. Patterns may use
- * the following special characters:
- *
- * - :paramName     Matches a URL segment up to the next /, ?, or #. The
- *                  captured string is considered a "param"
- * - ()             Wraps a segment of the URL that is optional
- * - *              Consumes (non-greedy) all characters up to the next
- *                  character in the pattern, or to the end of the URL if
- *                  there is none
- * - **             Consumes (greedy) all characters up to the next character
- *                  in the pattern, or to the end of the URL if there is none
- *
- * The return value is an object with the following properties:
- *
- * - remainingPathname
- * - paramNames
- * - paramValues
- */
-export function matchPattern(pattern, pathname) {
+* Attempts to match a pattern on the given pathname. Patterns may use
+* the following special characters:
+*
+* - :paramName     Matches a URL segment up to the next /, ?, or #. The
+*                  captured string is considered a "param"
+* - ()             Wraps a segment of the URL that is optional
+* - *              Consumes (non-greedy) all characters up to the next
+*                  character in the pattern, or to the end of the URL if
+*                  there is none
+* - **             Consumes (greedy) all characters up to the next character
+*                  in the pattern, or to the end of the URL if there is none
+*
+* The return value is an object with the following properties:
+*
+* - remainingPathname
+* - paramNames
+* - paramValues
+*/
+export function matchPattern(pattern: string, pathname: string) {
   // Make leading slashes consistent between pattern and pathname.
-  if (pattern.charAt(0) !== '/') {
-    pattern = `/${pattern}`
+  if( pattern.charAt(0) !== '/' ) {
+    pattern = `/${pattern}`;
   }
-  if (pathname.charAt(0) !== '/') {
-    pathname = `/${pathname}`
+  if( pathname.charAt(0) !== '/' ) {
+    pathname = `/${pathname}`;
   }
 
-  let { regexpSource, paramNames, tokens } = compilePattern(pattern)
+  let { regexpSource, paramNames, tokens } = compilePattern(pattern);
 
-  regexpSource += '/*' // Capture path separators
+  regexpSource += '/*'; // Capture path separators
 
   // Special-case patterns like '*' for catch-all routes.
   if (tokens[tokens.length - 1] === '*') {
-    regexpSource += '$'
+    regexpSource += '$';
   }
 
-  const match = pathname.match(new RegExp(`^${regexpSource}`, 'i'))
+  const match = pathname.match(new RegExp(`^${regexpSource}`, 'i'));
 
-  let remainingPathname, paramValues
-  if (match != null) {
+  let remainingPathname: string;
+  let paramValues: string[];
+
+  if( match != null ) {
     const matchedPath = match[0]
     remainingPathname = pathname.substr(matchedPath.length)
 
     // If we didn't match the entire pathname, then make sure that the match we
     // did get ends at a path separator (potentially the one we added above at
     // the beginning of the path, if the actual match was empty).
-    if (
+    if(
       remainingPathname &&
       matchedPath.charAt(matchedPath.length - 1) !== '/'
     ) {
@@ -121,80 +142,92 @@ export function matchPattern(pattern, pathname) {
         remainingPathname: null,
         paramNames,
         paramValues: null
-      }
+      };
     }
 
-    paramValues = match.slice(1).map(v => v && decodeURIComponent(v))
-  } else {
-    remainingPathname = paramValues = null
+    paramValues = match.slice(1).map(v => v && decodeURIComponent(v));
+  }
+  else {
+    remainingPathname = paramValues = null;
   }
 
   return {
     remainingPathname,
     paramNames,
     paramValues
-  }
+  };
 }
 
-export function getParamNames(pattern) {
-  return compilePattern(pattern).paramNames
+export function getParamNames(pattern: string) {
+  return compilePattern(pattern).paramNames;
 }
 
-export function getParams(pattern, pathname) {
-  const { paramNames, paramValues } = matchPattern(pattern, pathname)
+export function getParams(pattern: string, pathname: string) {
+  const { paramNames, paramValues } = matchPattern(pattern, pathname);
 
   if (paramValues != null) {
     return paramNames.reduce(function (memo, paramName, index) {
-      memo[paramName] = paramValues[index]
-      return memo
-    }, {})
+      memo[paramName] = paramValues[index];
+      return memo;
+    }, {});
   }
 
-  return null
+  return null;
 }
 
 /**
- * Returns a version of the given pattern with params interpolated. Throws
- * if there is a dynamic segment of the pattern for which there is no param.
- */
-export function formatPattern(pattern, params) {
-  params = params || {}
+* Returns a version of the given pattern with params interpolated. Throws
+* if there is a dynamic segment of the pattern for which there is no param.
+*/
+export function formatPattern(pattern: string, params: Params = {}) {
+  const { tokens } = compilePattern(pattern);
+  let parenCount = 0;
+  let pathname = '';
+  let splatIndex = 0;
 
-  const { tokens } = compilePattern(pattern)
-  let parenCount = 0, pathname = '', splatIndex = 0
+  let token: string;
+  let paramName: string;
+  let paramValue;
 
-  let token, paramName, paramValue
-  for (let i = 0, len = tokens.length; i < len; ++i) {
+  for(let i = 0, len = tokens.length; i < len; ++i) {
     token = tokens[i]
 
     if (token === '*' || token === '**') {
-      paramValue = Array.isArray(params.splat) ? params.splat[splatIndex++] : params.splat
+      paramValue = Array.isArray(params['splat']) ?
+        params['splat'][splatIndex++] :
+        params['splat'];
 
       if( paramValue != null || parenCount > 0 ) {
-        console.error('Missing splat #%s for path "%s"',   splatIndex, pattern)
+        console.error('Missing splat #%s for path "%s"',   splatIndex, pattern);
       }
 
-      if (paramValue != null)
-        pathname += encodeURI(paramValue)
-    } else if (token === '(') {
+      if( paramValue != null ) {
+        pathname += encodeURI(paramValue);
+      }
+    }
+    else if( token === '(' ) {
       parenCount += 1
-    } else if (token === ')') {
+    }
+    else if( token === ')' ) {
       parenCount -= 1
-    } else if (token.charAt(0) === ':') {
-      paramName = token.substring(1)
-      paramValue = params[paramName]
+    }
+    else if( token.charAt(0) === ':' ) {
+      paramName = token.substring(1);
+      paramValue = params[paramName];
 
       if( paramValue != null || parenCount > 0 ) {
         console.error('Missing "%s" parameter for path "%s"',
-        paramName, pattern)
+        paramName, pattern);
       }
 
-      if (paramValue != null)
-        pathname += encodeURIComponent(paramValue)
-    } else {
-      pathname += token
+      if( paramValue != null ) {
+        pathname += encodeURIComponent(paramValue);
+      }
+    }
+    else {
+      pathname += token;
     }
   }
 
-  return pathname.replace(/\/+/g, '/')
+  return pathname.replace(/\/+/g, '/');
 }

--- a/lib/match-route.ts
+++ b/lib/match-route.ts
@@ -1,24 +1,168 @@
 /**
- * This is a fork of react-router's MatchRoute. Instead of async callbacks, it
- * uses observables to perform async traversal of a route trie. It is expanded
- * to run route guards as part of the traversal process
- */
+* This is a fork of react-router's MatchRoute. Instead of async callbacks, it
+* uses observables to perform async traversal of a route trie. It is expanded
+* to run route guards as part of the traversal process
+*/
 import 'rxjs/add/observable/of';
 import 'rxjs/add/observable/merge';
 import 'rxjs/add/operator/mergeMap';
+import 'rxjs/add/operator/let';
 import 'rxjs/add/operator/toArray';
+import 'rxjs/add/operator/catch';
 import { Observable } from 'rxjs/Observable';
-import { Injector } from 'angular2/core';
+import { OpaqueToken, Provider, Inject, Injectable } from 'angular2/core';
 
-import { fromCallback } from './util';
+import { fromCallback, compose } from './util';
 import { matchPattern } from './match-pattern';
 import { Route, IndexRoute, Routes } from './route';
-import { runGuards } from './guard';
+import { Middleware, provideMiddlewareForToken, identity } from './middleware';
+
+const TRAVERSAL_MIDDLEWARE = new OpaqueToken(
+  '@ngrx/router Traversal Middleware'
+);
+
+export const useTraversalMiddleware = provideMiddlewareForToken(
+  TRAVERSAL_MIDDLEWARE
+);
 
 export interface Match {
   routes: Routes;
   params: any;
- };
+};
+
+
+@Injectable()
+export class RouteTraverser {
+  constructor(@Inject(TRAVERSAL_MIDDLEWARE) private _middleware: Middleware[]){ }
+
+  /**
+  * Asynchronously matches the given location to a set of routes and calls
+  * callback(error, state) when finished. The state object will have the
+  * following properties:
+  *
+  * - routes       An array of routes that matched, in hierarchical order
+  * - params       An object of URL parameters
+  */
+  matchRoutes(
+    routes: Routes,
+    pathname: string,
+    remainingPathname = pathname,
+    paramNames = [],
+    paramValues = []
+  ): Observable<Match> {
+    const seekers = routes.map<Observable<Match>>(route => Observable.of(route)
+      .let<boolean>(compose(...this._middleware))
+      .mergeMap(canTraverse => {
+        if( canTraverse ) {
+          return this._matchRouteDeep(
+            route,
+            pathname,
+            remainingPathname,
+            paramNames,
+            paramValues
+          );
+        }
+
+        return Observable.of(null);
+      })
+      .catch(error => {
+        console.error(error);
+        return Observable.of(null);
+      })
+    );
+
+    return Observable
+      .merge(...seekers)
+      .toArray()
+      .map(matches => matches.filter(match => !!match)[0]);
+  }
+
+  private _matchRouteDeep(
+    route: Route,
+    pathname: string,
+    remainingPathname: string,
+    paramNames: string[],
+    paramValues: string[]
+  ): Observable<Match> {
+    const pattern = route.path || '';
+
+    if( pattern.charAt(0) === '/' ) {
+      remainingPathname = pathname;
+      paramNames = [];
+      paramValues = [];
+    }
+
+    if( remainingPathname !== null ) {
+      const matched = matchPattern(pattern, remainingPathname);
+      remainingPathname = matched.remainingPathname;
+      paramNames = [ ...paramNames, ...matched.paramNames ];
+      paramValues = [ ...paramValues, ...matched.paramValues ];
+
+      if( remainingPathname === '' && route.path ) {
+        const match: Match = {
+          routes: [ route ],
+          params: assignParams(paramNames, paramValues)
+        };
+
+        return getIndexRoute(route)
+          .map(indexRoute => {
+            if( !!indexRoute ) {
+              match.routes.push(indexRoute);
+            }
+
+            return match;
+          });
+      }
+    }
+
+    if( remainingPathname != null ) {
+      return getChildRoutes(route)
+        .mergeMap(childRoutes => this.matchRoutes(
+          childRoutes,
+          pathname,
+          remainingPathname,
+          paramNames,
+          paramValues
+        ))
+        .map(match => {
+          if( !!match ) {
+            match.routes.unshift(route);
+
+            return match;
+          }
+
+          return null;
+        });
+    }
+    else {
+      return Observable.of(null);
+    }
+  }
+}
+
+export const MATCH_ROUTE_PROVIDERS = [
+  new Provider(RouteTraverser, { useClass: RouteTraverser }),
+  useTraversalMiddleware(identity)
+];
+
+
+export function assignParams(paramNames: string[], paramValues: string[]) {
+  return paramNames.reduce(function (params, paramName, index) {
+    const paramValue = paramValues && paramValues[index];
+
+    if( Array.isArray(params[paramName]) ){
+      params[paramName].push(paramValue);
+    }
+    else if (paramName in params) {
+      params[paramName] = [ params[paramName], paramValue ];
+    }
+    else {
+      params[paramName] = paramValue;
+    }
+
+    return params;
+  }, {});
+}
 
 function getChildRoutes(route: Route): Observable<Routes> {
   if ( !!route.children ) {
@@ -42,128 +186,4 @@ function getIndexRoute(route: Route): Observable<IndexRoute> {
   }
 
   return fromCallback<IndexRoute>(route.loadIndexRoute);
-}
-
-export function assignParams(paramNames: string[], paramValues: string[]) {
-  return paramNames.reduce(function (params, paramName, index) {
-    const paramValue = paramValues && paramValues[index];
-
-    if( Array.isArray(params[paramName]) ){
-      params[paramName].push(paramValue);
-    }
-    else if (paramName in params) {
-      params[paramName] = [ params[paramName], paramValue ];
-    }
-    else {
-      params[paramName] = paramValue;
-    }
-
-    return params;
-  }, {});
-}
-
-export function matchRouteDeep(
-  injector: Injector,
-  route: Route,
-  pathname: string,
-  remainingPathname: string,
-  paramNames: string[],
-  paramValues: string[]
-): Observable<Match> {
-  const pattern = route.path || '';
-
-  if( pattern.charAt(0) === '/' ) {
-    remainingPathname = pathname;
-    paramNames = [];
-    paramValues = [];
-  }
-
-  if( remainingPathname !== null ) {
-    const matched = matchPattern(pattern, remainingPathname);
-    remainingPathname = matched.remainingPathname;
-    paramNames = [ ...paramNames, ...matched.paramNames ];
-    paramValues = [ ...paramValues, ...matched.paramValues ];
-
-    if( remainingPathname === '' && route.path ) {
-      const match: Match = {
-        routes: [ route ],
-        params: assignParams(paramNames, paramValues)
-      };
-
-      return getIndexRoute(route)
-        .map(indexRoute => {
-          if( !!indexRoute ) {
-            match.routes.push(indexRoute);
-          }
-
-          return match;
-        });
-    }
-  }
-
-  if( remainingPathname != null ) {
-    return getChildRoutes(route)
-      .mergeMap(childRoutes => matchRoutes(
-        injector,
-        childRoutes,
-        pathname,
-        remainingPathname,
-        paramNames,
-        paramValues
-      ))
-      .map(match => {
-        if( !!match ) {
-          match.routes.unshift(route);
-
-          return match;
-        }
-
-        return null;
-      });
-  }
-  else {
-    return Observable.of(null);
-  }
-}
-
-
-/**
- * Asynchronously matches the given location to a set of routes and calls
- * callback(error, state) when finished. The state object will have the
- * following properties:
- *
- * - routes       An array of routes that matched, in hierarchical order
- * - params       An object of URL parameters
- */
-export function matchRoutes(
-  injector: Injector,
-  routes: Routes,
-  pathname: string,
-  remainingPathname = pathname,
-  paramNames = [],
-  paramValues = []
-): Observable<Match> {
-  const seekers = routes.map(route => {
-    return runGuards(injector, route)
-      .flatMap(canTraverse => {
-        if( canTraverse ) {
-          return matchRouteDeep(
-            injector,
-            route,
-            pathname,
-            remainingPathname,
-            paramNames,
-            paramValues
-          );
-        }
-
-        return Observable.of(null);
-      });
-  });
-
-  return Observable
-    .merge(...seekers)
-    .toArray()
-    .map(matches => matches.filter(match => !!match))
-    .map(matches => matches[0])
 }


### PR DESCRIPTION
Previously we were running guards as part of route traversal. This PR refactors route traversal to expose a middleware hook called traversal middleware. 

They run before a route is traversed and transform a stream of routes into a stream of boolean values. If the stream returns false, the traverser aborts traversing that route.

Refactored guards to use traversal middleware.