### PR TITLE
fix(Location): Cleaned up Location service

### DIFF
--- a/lib/query-params.ts
+++ b/lib/query-params.ts
@@ -20,7 +20,7 @@ export class QueryParams extends ReplaySubject<{ [param: string]: any }>{
   replace(params = {}) {
     const [ pathname ] = this._location.path().split('?');
 
-    this._location.replaceState(pathname, stringifyQueryParams(params));
+    this._location.replaceState(pathname, params);
   }
 }
 

--- a/lib/route-set.ts
+++ b/lib/route-set.ts
@@ -44,10 +44,10 @@ function createRouteSet(
 ): RouteSet {
   return location$
     .observeOn(queue)
-    .distinctUntilChanged((prev, next) => prev.url === next.url)
+    .distinctUntilChanged((prev, next) => prev.path === next.path)
     .let<LocationChange>(compose(...locationMiddleware))
-    .switchMap(() => {
-      const [ pathname, queryString ] = location$.path().split('?');
+    .switchMap(change => {
+      const [ pathname, queryString ] = change.path.split('?');
 
       return traverser.find(pathname)
         .map<NextRoute>(set => {

--- a/spec/location.spec.ts
+++ b/spec/location.spec.ts
@@ -90,7 +90,7 @@ describe('Location', () => {
   it('should update subject on location update', (done) => {
     location.go('/update/path');
     location.subscribe((ev) => {
-      expect(ev['url']).toEqual('/update/path');
+      expect(ev.path).toEqual('/update/path');
       done();
     });
   });
@@ -98,7 +98,7 @@ describe('Location', () => {
   it('should update subject on location replaceState', (done) => {
     location.replaceState('/replace/path');
     location.subscribe((ev) => {
-      expect(ev['url']).toEqual('/replace/path');
+      expect(ev.path).toEqual('/replace/path');
       done();
     });
   });

--- a/spec/query-params.spec.ts
+++ b/spec/query-params.spec.ts
@@ -73,14 +73,15 @@ describe('QueryParams Service', function() {
   });
 
   it('should replace the query string', function() {
-    params$.replace({ test: 123 });
+    const next = { test: 123 };
+    params$.replace(next);
 
-    expect(mockLocation.replaceState).toHaveBeenCalledWith('/test', 'test=123');
+    expect(mockLocation.replaceState).toHaveBeenCalledWith('/test', next);
   });
 
   it('should replace the query string with an empty value', function() {
     params$.replace();
 
-    expect(mockLocation.replaceState).toHaveBeenCalledWith('/test', '');
+    expect(mockLocation.replaceState).toHaveBeenCalledWith('/test', {});
   })
 });


### PR DESCRIPTION
LocationChange events are now more consistent and useful. The go and replaceState methods now accept objects instead of just query strings.