### PR TITLE
chore(License): Updated copyright notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2016 Brandon Roberts, Mike Ryan
+Portions Copyright (c) 2015 Ryan Florence, Michael Jackson
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -1,14 +1,17 @@
 {
   "name": "@ngrx/router",
   "version": "0.0.1",
-  "description": "",
+  "description": "A reactive router for Angular 2",
   "main": "index.js",
   "scripts": {
     "build": "gulp build",
     "test": "karma start",
-    "postinstall": "typings install"
+    "installtypings": "typings install"
   },
-  "author": "",
+  "authors": [
+    "Mike Ryan",
+    "Brandon Roberts"
+  ],
   "license": "MIT",
   "peerDependencies": {
     "angular2": "^2.0.0-beta.9",


### PR DESCRIPTION
Updates copyright notice to include original copyright holders.

Files that came from react-router:

* `/lib/match-pattern.ts`
* `/lib/match-route.ts`

cc @mjackson and @ryanflorence