### PR TITLE
Improved Traversal Middleware

### DIFF
--- a/lib/guard.ts
+++ b/lib/guard.ts
@@ -19,27 +19,36 @@ import { provide, Provider, OpaqueToken, Injector } from 'angular2/core';
 
 import { createFactoryProvider } from './util';
 import { Route } from './route';
-import { useTraversalMiddleware } from './match-route';
+import { useTraversalMiddleware, TraversalCandidate } from './match-route';
 import { createMiddleware } from './middleware';
 
 export interface Guard {
-  (route: Route): Observable<boolean>;
+  (route: Route, params: any, isTerminal: boolean): Observable<boolean>;
 }
 
 export const createGuard = createFactoryProvider<Guard>('@ngrx/router Guard');
 
 export const guardMiddleware = createMiddleware(function(injector: Injector) {
-  return (route$: Observable<Route>) => route$
-    .mergeMap(route => {
+  return (route$: Observable<TraversalCandidate>) => route$
+    .mergeMap<TraversalCandidate>(({ route, params, isTerminal }) => {
       if( !!route.guards && Array.isArray(route.guards) && route.guards.length > 0 ) {
-        const resolved: Guard[] = route.guards
+        const guards: Guard[] = route.guards
           .map(provider => injector.resolveAndInstantiate(provider));
 
-        return Observable.merge<boolean>(...resolved.map(guard => guard(route)))
-          .every(value => !!value);
+        const resolved = guards.map(guard => guard(route, params, isTerminal));
+
+        return Observable.merge(...resolved)
+          .every(value => !!value)
+          .map(passed => {
+            if( passed ) {
+              return { route, params };
+            }
+
+            return { route: null, params, isTerminal };
+          })
       }
 
-      return Observable.of(true);
+      return Observable.of({ route, params, isTerminal });
     });
 }, [ Injector ]);
 

--- a/lib/guard.ts
+++ b/lib/guard.ts
@@ -14,6 +14,8 @@ import 'rxjs/add/observable/merge';
 import 'rxjs/add/observable/of';
 import 'rxjs/add/operator/mergeMap';
 import 'rxjs/add/operator/every';
+import 'rxjs/add/operator/observeOn';
+import { asap } from 'rxjs/scheduler/asap';
 import { Observable } from 'rxjs/Observable';
 import { provide, Provider, OpaqueToken, Injector } from 'angular2/core';
 
@@ -38,6 +40,7 @@ export const guardMiddleware = createMiddleware(function(injector: Injector) {
         const resolved = guards.map(guard => guard(route, params, isTerminal));
 
         return Observable.merge(...resolved)
+          .observeOn(asap)
           .every(value => !!value)
           .map(passed => {
             if( passed ) {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -39,6 +39,6 @@ export { RouteParams } from './route-params';
 export { useLocationMiddleware, useRouteSetMiddleware, RouteSet, NextRoute } from './route-set';
 export { usePreRenderMiddleware, usePostRenderMiddleware, RenderInstruction } from './component-renderer';
 export { Routes, Route, IndexRoute } from './route';
-export { useTraversalMiddleware } from './match-route';
+export { useTraversalMiddleware, TraversalCandidate } from './match-route';
 export { QueryParams } from './query-params';
 export { LinkTo } from './link-to';

--- a/lib/match-route.ts
+++ b/lib/match-route.ts
@@ -10,7 +10,6 @@ import 'rxjs/add/operator/let';
 import 'rxjs/add/operator/toArray';
 import 'rxjs/add/operator/catch';
 import 'rxjs/add/operator/map';
-import 'rxjs/add/operator/every';
 import { Observable } from 'rxjs/Observable';
 import { OpaqueToken, Provider, Inject, Injectable } from 'angular2/core';
 

--- a/lib/match-route.ts
+++ b/lib/match-route.ts
@@ -73,7 +73,7 @@ export class RouteTraverser {
         paramValues
       )
       .catch(error => {
-        console.error('Error During Traversa', error);
+        console.error('Error During Traversal', error);
         return Observable.of(null);
       });
     });

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -1,3 +1,4 @@
+import 'rxjs/add/observable/bindCallback';
 import { Observable } from 'rxjs/Observable';
 import { Subscriber } from 'rxjs/Subscriber';
 import { provide, Provider, OpaqueToken } from 'angular2/core';
@@ -5,12 +6,7 @@ import { provide, Provider, OpaqueToken } from 'angular2/core';
 export type Callback<T> = (callback: (value: T) => void ) => void;
 
 export function fromCallback<T>(fn: Callback<T>) {
-  return new Observable<T>((sub: Subscriber<T>) => {
-    fn((value) => {
-      sub.next(value);
-      sub.complete();
-    });
-  });
+  return Observable.bindCallback(fn)()
 }
 
 export function createFactoryProvider<T>(

--- a/spec/link-to.spec.ts
+++ b/spec/link-to.spec.ts
@@ -8,12 +8,12 @@ import {
   injectAsync,
   expect
 } from 'angular2/testing';
-import {
-  Component
-} from 'angular2/core';
+import { Component, provide } from 'angular2/core';
 import { LinkTo } from '../lib/link-to';
 import { LOCATION_PROVIDERS, Location } from '../lib/location';
 import { Observable } from 'rxjs/Observable';
+import { LocationStrategy } from 'angular2/src/router/location/location_strategy';
+import { MockLocationStrategy } from 'angular2/src/mock/mock_location_strategy';
 
 @Component({
   selector: 'link-test',
@@ -30,7 +30,8 @@ const compile = (tcb: TestComponentBuilder, template: string = '') => {
 
 describe('Link To', () => {
   beforeEachProviders(() => [
-    LOCATION_PROVIDERS
+    LOCATION_PROVIDERS,
+    provide(LocationStrategy, { useClass: MockLocationStrategy })
   ]);
 
   it('should be defined', () => {


### PR DESCRIPTION
Traversal middleware now receives the matched route, a preview of route params, and whether or not traversal plans on terminating on that route. Traversal middleware can:

* Null out the route to stop traversing that route
* Mark the candidate as terminal to force traversal to select that route
* If the route is marked as terminal it can modify the final route params

With this change, guards will only run if the route they are installed on is an actual candidate. This should make it safe to perform redirections inside of guards. They also now receive a preview of route params as their second argument.

cc @laurelnaiad and @fxck