### PR TITLE
feat(AsyncConfig): Refactor route config to use promises instead of callbacks

### DIFF
--- a/docs/getting-started/code-splitting.md
+++ b/docs/getting-started/code-splitting.md
@@ -11,24 +11,24 @@ import { Routes } from 'ngrx/router';
 export const routes: Routes = [
   {
     path: '/',
-    loadComponent(done) {
+    loadComponent: () => new Promise(resolve => {
       require.ensure([], require => {
-        done(require('./pages/home').HomePage);
+        resolve(require('./pages/home').HomePage);
       })
-    }
+    })
   },
   {
     path: '/blog',
-    loadComponent(done) {
+    loadComponent: () => new Promise(resolve => {
       require.ensure([], require => {
-        done(require('./pages/blog').BlogPage);
+        resolve(require('./pages/blog').BlogPage);
       })
-    },
-    loadChildren(done) {
+    }),
+    loadChildren: () => new Promise(resolve => {
       require.ensure([], require => {
-        done(require('./blog-routes').blogRoutes);
+        resolve(require('./blog-routes').blogRoutes);
       })
-    }
+    })
   }
 ]
 ```
@@ -40,11 +40,11 @@ import { Routes } from 'ngrx/router';
 export const blogRoutes: Routes = [
   {
     path: ':id',
-    loadComponent(done) {
+    loadComponent: () => new Promise(resolve => {
       require.ensure([], require => {
-        done(require('./pages/post').PostPage);
+        resolve(require('./pages/post').PostPage);
       });
-    }
+    })
   }
 ]
 ```

--- a/docs/getting-started/guards.md
+++ b/docs/getting-started/guards.md
@@ -39,14 +39,10 @@ const routes: Routes = [
   {
     path: '/account',
     guards: [ authGuard ],
-    loadComponent(done) {
-      System.load('/pages/account')
-        .then(module => done(module.AccountPage));
-    },
-    loadChildren(done) {
-      System.load('/routes/account')
-        .then(module => done(module.accountRoutes));
-    }
+    loadComponent: () => System.import('/pages/account', __moduleName)
+      .then(module => module.AccountPage),
+    loadChildren: () => System.import('/routes/account', __moduleName))
+      .then(module => module.accountRoutes),
   }
 ]
 ```

--- a/lib/resource-loader.ts
+++ b/lib/resource-loader.ts
@@ -1,0 +1,23 @@
+import { Injectable, Provider } from 'angular2/core';
+
+export type Async<T> = () => Promise<T>;
+
+@Injectable()
+export class ResourceLoader {
+  load<T>(sync: T, async: Async<T>, defaultValue?: any): Promise<T> {
+    if (!!sync) {
+      return Promise.resolve(sync);
+    }
+
+    else if (!!async) {
+      return Promise.resolve(async());
+    }
+
+    return Promise.resolve(defaultValue);
+  }
+}
+
+
+export const RESOURCE_LOADER_PROVIDERS = [
+  new Provider(ResourceLoader, { useClass: ResourceLoader })
+];

--- a/lib/route.ts
+++ b/lib/route.ts
@@ -4,13 +4,13 @@
 import { Observable } from 'rxjs/Observable';
 import { Provider, Type, OpaqueToken } from 'angular2/core';
 
-import { Callback } from './util';
+import { Async } from './resource-loader';
 
 export type Routes = Array<Route>;
 
 export interface IndexRoute {
   component?: Type;
-  loadComponent?: Callback<Type>;
+  loadComponent?: Async<Type>;
   redirectTo?: string;
 }
 
@@ -18,9 +18,9 @@ export interface Route extends IndexRoute {
   path?: string;
   guards?: Provider[];
   indexRoute?: IndexRoute;
-  loadIndexRoute?: Callback<IndexRoute>;
+  loadIndexRoute?: Async<IndexRoute>;
   children?: Routes;
-  loadChildren?: Callback<Routes>;
+  loadChildren?: Async<Routes>;
 }
 
 export const ROUTES = new OpaqueToken('@ngrx/router Init Routes');

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -1,13 +1,6 @@
-import 'rxjs/add/observable/bindCallback';
 import { Observable } from 'rxjs/Observable';
 import { Subscriber } from 'rxjs/Subscriber';
 import { provide, Provider, OpaqueToken } from 'angular2/core';
-
-export type Callback<T> = (callback: (value: T) => void ) => void;
-
-export function fromCallback<T>(fn: Callback<T>) {
-  return Observable.bindCallback(fn)();
-}
 
 export function createFactoryProvider<T>(
   name: string,

--- a/spec/component-renderer.spec.ts
+++ b/spec/component-renderer.spec.ts
@@ -2,6 +2,8 @@ import 'rxjs/add/operator/toPromise';
 import { Subject } from 'rxjs/Subject';
 import { Observable } from 'rxjs/Observable';
 import { Injector, provide, DynamicComponentLoader, ElementRef } from 'angular2/core';
+
+import { RESOURCE_LOADER_PROVIDERS } from '../lib/resource-loader';
 import { Location } from '../lib/location';
 import {
   ComponentRenderer,
@@ -35,7 +37,8 @@ describe('Component Renderer', function() {
         ComponentRenderer,
         provide(PRE_RENDER_MIDDLEWARE, { useValue: [] }),
         provide(POST_RENDER_MIDDLEWARE, { useValue: [] }),
-        provide(DynamicComponentLoader, {useClass: MockDCL})
+        provide(DynamicComponentLoader, {useClass: MockDCL}),
+        RESOURCE_LOADER_PROVIDERS
       ]);
 
       renderer = injector.get(ComponentRenderer);
@@ -54,10 +57,9 @@ describe('Component Renderer', function() {
 
     it('should render a loaded component', (done) => {
       route = {
-        loadComponent(cb) {
-          cb(TestComponent);
-        }
+        loadComponent: () => Promise.resolve(TestComponent)
       };
+
       let render = renderer.render(route, injector, <ElementRef>elementRef, loader, providers);
 
       render.subscribe(() => {
@@ -95,7 +97,8 @@ describe('Component Renderer', function() {
         ComponentRenderer,
         usePreRenderMiddleware(renderMiddleware),
         provide(POST_RENDER_MIDDLEWARE, {useValue: []}),
-        provide(DynamicComponentLoader, {useClass: MockDCL})
+        provide(DynamicComponentLoader, {useClass: MockDCL}),
+        RESOURCE_LOADER_PROVIDERS
       ]);
 
       renderer = injector.get(ComponentRenderer);
@@ -152,7 +155,8 @@ describe('Component Renderer', function() {
         ComponentRenderer,
         usePostRenderMiddleware(renderMiddleware),
         provide(PRE_RENDER_MIDDLEWARE, {useValue: []}),
-        provide(DynamicComponentLoader, {useClass: MockDCL})
+        provide(DynamicComponentLoader, {useClass: MockDCL}),
+        RESOURCE_LOADER_PROVIDERS
       ]);
 
       renderer = injector.get(ComponentRenderer);

--- a/spec/match-route.spec.ts
+++ b/spec/match-route.spec.ts
@@ -1,4 +1,6 @@
 import { Injector, provide } from 'angular2/core';
+
+import { RESOURCE_LOADER_PROVIDERS } from '../lib/resource-loader';
 import { Routes, Route, ROUTES } from '../lib/route';
 import { RouteTraverser, MATCH_ROUTE_PROVIDERS } from '../lib/match-route';
 
@@ -70,6 +72,7 @@ describe('RouteTraverser', function() {
   beforeEach(function() {
     const injector = Injector.resolveAndCreate([
       MATCH_ROUTE_PROVIDERS,
+      RESOURCE_LOADER_PROVIDERS,
       provide(ROUTES, { useValue: routes })
     ]);
     traverser = injector.get(RouteTraverser);
@@ -267,9 +270,7 @@ describe('RouteTraverser', function() {
         if ( children ) {
           delete route.children;
 
-          route.loadChildren = function(done) {
-            setTimeout(() => done(children));
-          };
+          route.loadChildren = () => Promise.resolve(children);
 
           makeAsyncRouteConfig(children);
         }
@@ -277,9 +278,7 @@ describe('RouteTraverser', function() {
         if ( indexRoute ) {
           delete route.indexRoute;
 
-          route.loadIndexRoute = function(done) {
-            setTimeout(() => done(indexRoute));
-          };
+          route.loadIndexRoute = () => Promise.resolve(indexRoute);
         }
       });
     }

--- a/spec/util.spec.ts
+++ b/spec/util.spec.ts
@@ -1,22 +1,8 @@
 import { Injector, Provider, OpaqueToken } from 'angular2/core';
-import { Callback, fromCallback, createFactoryProvider, compose } from '../lib/util';
+import { createFactoryProvider, compose } from '../lib/util';
 
 
 describe('Router Utilities', function() {
-  describe('fromCallback Helper', function() {
-    it('should wrap a callback function in an observable', function(done) {
-      const callback: Callback<number> = function(done) {
-        done(123);
-      };
-
-      fromCallback(callback).subscribe(value => {
-        expect(value).toBe(123);
-
-        done();
-      });
-    });
-  });
-
   describe('createFactoryProvider Helper', function() {
     it('should create a factory function for anonymous providers', function() {
       const factory = createFactoryProvider('test');


### PR DESCRIPTION
Promises are more zone-aware than callbacks. They also work better with rx operators like mergeMap, switchMap, etc.

BREAKING CHANGE: Before loadComponent, loadChildren, and loadIndexRoute used a callback to handle async loading of code. These must be replaced with promise-returning functions.

  Before:
```ts
  {
    loadIndex(done) {
      System.import('./my-index-route', __moduleName)
        .then(module => done(module.indexRoute));
    },
    loadComponent(done) {
      System.import('./my-component', __moduleName)
        .then(module => done(module.MyComponent));
    },
    loadChildren(done) {
      System.import('./child-routes', __moduleName)
        .then(module => done(module.routes));
    }
  }
```
  After:
```ts
  {
    loadIndex: () => System.import('./my-index-route', __moduleName)
      .then(module => module.indexRoute),

    loadComponent: () => System.import('./my-component', __moduleName)
      .then(module => module.MyComponent),

    loadChildren: () => System.import('./child-routes', __moduleName)
      .then(module => module.routes)
  }
```