### PR TITLE
feat(NamedComponents): Add ability to configure named components

### DIFF
--- a/docs/getting-started/code-splitting.md
+++ b/docs/getting-started/code-splitting.md
@@ -30,7 +30,7 @@ export const routes: Routes = [
       })
     })
   }
-]
+];
 ```
 
 In `blog-routes.ts`:
@@ -46,7 +46,24 @@ export const blogRoutes: Routes = [
       });
     })
   }
-]
+];
 ```
 
 Now our router will load route configuration and components as needed. This can have a dramatic impact on the amount of code your users will need to download up front in order to run your application.
+
+## Named Routes
+Just like you can use `components` instead of `component` to specify a map of named components, you can do the same with `loadComponents`:
+
+```ts
+export const routes: Routes = [
+  {
+    path: '/blog',
+    loadComponents: {
+      main: () => System.import('/app/blog.ts')
+        .then(module => module.BlogPage),
+      sideMenu: () => System.import('/app/recent-posts.ts')
+        .then(module => module.RecentPosts)
+    }
+  }
+];
+```

--- a/docs/getting-started/route.md
+++ b/docs/getting-started/route.md
@@ -88,3 +88,36 @@ bootstrap(App, [
   provideRouter(routes)
 ]);
 ```
+
+## Named Components
+For composing more complex views, the `<route-view>` component can be instructed to use named components. In our route config, instead of supplying `component` we can supply `components`:
+
+```ts
+const routes: Routes = [
+  {
+    path: '/blog',
+    components: {
+      main: Blog,
+      sideMenu: RecentPosts
+    }
+  }
+]
+```
+
+Then in our `App` template we give each `<route-view />` a name:
+
+```ts
+@Component({
+  selector: 'app',
+  template: `
+    <section>
+      <route-view name="main"></route-view>
+    </section>
+
+    <aside>
+      <route-view name="sideMenu"></route-view>
+    </aside>
+  `
+})
+export class App { }
+```

--- a/lib/component-renderer.ts
+++ b/lib/component-renderer.ts
@@ -18,7 +18,7 @@ import { Observable } from 'rxjs/Observable';
 
 import { Async, ResourceLoader } from './resource-loader';
 import { compose } from './util';
-import { Route } from './route';
+import { Route, SimpleRoute } from './route';
 import { Middleware, identity, provideMiddlewareForToken } from './middleware';
 
 export const PRE_RENDER_MIDDLEWARE = new OpaqueToken(
@@ -60,13 +60,14 @@ export class ComponentRenderer {
 
   render(
     route: Route,
+    components: SimpleRoute,
     injector: Injector,
     ref: ElementRef,
     dcl: DynamicComponentLoader,
     providers: Provider[]
   ) {
     return Observable.of(route)
-      .mergeMap(route => this._loadComponent(route))
+      .mergeMap(route => this._loadComponent(components))
       .map<RenderInstruction>(component => {
         return { component, injector, providers };
       })
@@ -85,7 +86,7 @@ export class ComponentRenderer {
     return dcl.loadNextToLocation(component, ref, providers);
   }
 
-  private _loadComponent(route: Route): Promise<Type> {
+  private _loadComponent(route: SimpleRoute): Promise<Type> {
     return this._loader.load(route.component, route.loadComponent);
   }
 }

--- a/lib/route.ts
+++ b/lib/route.ts
@@ -8,9 +8,14 @@ import { Async } from './resource-loader';
 
 export type Routes = Array<Route>;
 
-export interface IndexRoute {
+export interface SimpleRoute {
   component?: Type;
   loadComponent?: Async<Type>;
+}
+
+export interface IndexRoute extends SimpleRoute {
+  components?: { [name: string]: Type };
+  loadComponents?: { [name: string]: Async<Type> };
   redirectTo?: string;
 }
 
@@ -24,3 +29,14 @@ export interface Route extends IndexRoute {
 }
 
 export const ROUTES = new OpaqueToken('@ngrx/router Init Routes');
+
+export function getNamedComponents(route: IndexRoute, name?: string): SimpleRoute {
+  if (!name) {
+    return { component: route.component, loadComponent: route.loadComponent };
+  }
+
+  const components = route.components || {};
+  const loadComponents = route.loadComponents || {};
+
+  return { component: components[name], loadComponent: loadComponents[name] };
+}

--- a/spec/component-renderer.spec.ts
+++ b/spec/component-renderer.spec.ts
@@ -12,22 +12,24 @@ import {
   usePreRenderMiddleware,
   usePostRenderMiddleware
 } from '../lib/component-renderer';
-import { Route } from '../lib/route';
+import { Route, SimpleRoute } from '../lib/route';
 import { createMiddleware } from '../lib/middleware';
 
 class MockDCL {
-  loadNextToLocation: Function = jasmine.createSpy('loadNextToLocation').and.returnValue(Observable.of(true).toPromise())
+  loadNextToLocation: Function = jasmine.createSpy('loadNextToLocation').and
+    .returnValue(Observable.of(true).toPromise());
 }
 
-class TestComponent{}
+class TestComponent {}
 
 describe('Component Renderer', function() {
   let route: Route,
+      components: SimpleRoute,
       renderer: ComponentRenderer,
       injector: Injector,
       loader: any;
 
-  describe('Rendering', () => {
+  describe('when rendering', () => {
     let route;
     let elementRef = {};
     let providers = [];
@@ -46,21 +48,24 @@ describe('Component Renderer', function() {
     });
 
     it('should render a component', (done) => {
-      route = { component: TestComponent };
-      let render = renderer.render(route, injector, <ElementRef>elementRef, loader, providers);
+      route = {};
+      components = { component: TestComponent };
+
+      let render = renderer.render(route, components, injector, <ElementRef>elementRef, loader, providers);
 
       render.subscribe(() => {
-        expect(loader.loadNextToLocation).toHaveBeenCalledWith(route.component, elementRef, providers);
+        expect(loader.loadNextToLocation).toHaveBeenCalledWith(TestComponent, elementRef, providers);
         done();
       });
     });
 
     it('should render a loaded component', (done) => {
-      route = {
+      route = { };
+      components = {
         loadComponent: () => Promise.resolve(TestComponent)
       };
 
-      let render = renderer.render(route, injector, <ElementRef>elementRef, loader, providers);
+      let render = renderer.render(route, components, injector, <ElementRef>elementRef, loader, providers);
 
       render.subscribe(() => {
         expect(loader.loadNextToLocation).toHaveBeenCalledWith(TestComponent, elementRef, providers);
@@ -106,7 +111,7 @@ describe('Component Renderer', function() {
     });
 
     beforeEach(() => {
-      render = renderer.render(route, injector, <ElementRef>elementRef, loader, providers);
+      render = renderer.render(route, route, injector, <ElementRef>elementRef, loader, providers);
     });
 
     it('should execute before rendering', (done) => {
@@ -164,7 +169,7 @@ describe('Component Renderer', function() {
     });
 
     beforeEach(() => {
-      render = renderer.render(route, injector, <ElementRef>elementRef, loader, providers);
+      render = renderer.render(route, route, injector, <ElementRef>elementRef, loader, providers);
     });
 
     it('should execute after rendering', (done) => {

--- a/spec/route.spec.ts
+++ b/spec/route.spec.ts
@@ -1,0 +1,36 @@
+import { IndexRoute, getNamedComponents } from '../lib/route';
+
+describe('Route', function() {
+  describe('getNamedComponents', function() {
+    class FixtureA { }
+    class FixtureB { }
+    const FixctureC = () => Promise.resolve(FixtureA);
+    const FixctureD = () => Promise.resolve(FixtureB);
+
+    it('should return the unnamed component when no name is provided', function() {
+      const resolved = getNamedComponents({
+        component: FixtureA,
+        loadComponent: FixctureC
+      });
+
+      expect(resolved.component).toBe(FixtureA);
+      expect(resolved.loadComponent).toBe(FixctureC);
+    });
+
+    it('should return the named component when a name is provided', function() {
+      const route: IndexRoute = {
+        components: {
+          main: FixtureB
+        },
+        loadComponents: {
+          main: FixctureD
+        }
+      };
+
+      const resolved = getNamedComponents(route, 'main');
+
+      expect(resolved.component).toBe(FixtureB);
+      expect(resolved.loadComponent).toBe(FixctureD);
+    });
+  });
+});


### PR DESCRIPTION
Route config can now accept named components

Using `components`:

```ts
const routes: Routes = [
  {
    path: '/blog',
    components: {
      main: Blog,
      sideMenu: RecentPosts
    }
  }
]
```

Using `loadComponents`:

```ts
export const routes: Routes = [
  {
    path: '/blog',
    loadComponents: {
      main: () => System.import('/app/blog.ts')
        .then(module => module.BlogPage),
      sideMenu: () => System.import('/app/recent-posts.ts')
        .then(module => module.RecentPosts)
    }
  }
];
```

Route views must be given a name to enable named component mode:

```html
<route-view name="main"></route-view>
```

Without a name, they'll default to using `component` or `loadComponent`

Closes #6