### PR TITLE
refactor(Middleware): Use generic type in Middleware interface

### DIFF
--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -7,14 +7,14 @@ import { OpaqueToken, Provider, provide, Injector } from 'angular2/core';
 
 import { compose, createProviderFactory } from './util';
 
-export interface Middleware {
-  (input$: Observable<any>): Observable<any>;
+export interface Middleware<T> {
+  (input$: Observable<T>): Observable<T>;
 }
 
-export const identity: Middleware = t => t;
+export const identity: Middleware<any> = t => t;
 
-export function createMiddleware(
-  useFactory: (...deps: any[]) => Middleware, deps?: any[]
+export function createMiddleware<T>(
+  useFactory: (...deps: any[]) => Middleware<T>, deps?: any[]
 ): Provider {
   return provide(new OpaqueToken('@ngrx/store middleware'), {
     deps,
@@ -27,7 +27,7 @@ export function provideMiddlewareForToken(token) {
     return t instanceof Provider;
   }
 
-  return function(..._middleware: Array<Middleware | Provider>): Provider[] {
+  return function(..._middleware: Array<Middleware<any> | Provider>): Provider[] {
     const provider = provide(token, {
       multi: true,
       deps: [ Injector ],

--- a/lib/router-instruction.ts
+++ b/lib/router-instruction.ts
@@ -8,6 +8,7 @@ import 'rxjs/add/operator/publishReplay';
 import 'rxjs/add/operator/let';
 import 'rxjs/add/operator/distinctUntilChanged';
 import 'rxjs/add/operator/observeOn';
+import 'rxjs/add/operator/last';
 import { Observable } from 'rxjs/Observable';
 import { queue } from 'rxjs/scheduler/queue';
 import { provide, Provider, Injector, OpaqueToken } from 'angular2/core';
@@ -49,13 +50,13 @@ export class RouterInstruction extends Observable<NextInstruction> { }
 function createRouterInstruction(
   location$: Location,
   traverser: RouteTraverser,
-  locationMiddleware: Middleware[],
-  routerInstructionMiddleware: Middleware[]
+  locationMiddleware: Middleware<LocationChange>[],
+  routerInstructionMiddleware: Middleware<NextInstruction>[]
 ): RouterInstruction {
   return location$
     .observeOn(queue)
     .distinctUntilChanged((prev, next) => prev.path === next.path)
-    .let<LocationChange>(compose(...locationMiddleware))
+    .let(compose(...locationMiddleware))
     .switchMap(change => {
       const [ pathname, queryString ] = change.path.split('?');
 
@@ -70,7 +71,7 @@ function createRouterInstruction(
         });
     })
     .filter(match => !!match)
-    .let<NextInstruction>(compose(...routerInstructionMiddleware))
+    .let(compose(...routerInstructionMiddleware))
     .publishReplay(1)
     .refCount();
 }

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -17,15 +17,11 @@ export function createProviderFactory<T>(
 }
 
 
-export function compose(...funcs) {
-  return function(...args) {
-    if (funcs.length === 0) {
-      return args[0];
-    }
-
+export function compose<T>(...funcs: Array<(input: T) => T>) {
+  return function(input: T) {
     const last = funcs[funcs.length - 1];
     const rest = funcs.slice(0, -1);
 
-    return rest.reduceRight((composed, f) => f(composed), last(...args));
+    return rest.reduceRight((composed, f) => f(composed), last(input));
   };
 };

--- a/spec/guard.spec.ts
+++ b/spec/guard.spec.ts
@@ -9,7 +9,7 @@ import { Guard, createGuard, guardMiddleware } from '../lib/guard';
 
 
 describe('Guard Middleware', function() {
-  let guardRunner: Middleware;
+  let guardRunner: Middleware<TraversalCandidate>;
   let injector: Injector;
 
   function route(route: Route, params = {}, isTerminal = false) {

--- a/spec/middleware.spec.ts
+++ b/spec/middleware.spec.ts
@@ -27,7 +27,7 @@ describe('Middleware', function() {
     ]);
 
     const middlewareArray = injector.get(testToken);
-    compose(...middlewareArray)();
+    compose(...middlewareArray)(null);
 
     expect(first.apply).toHaveBeenCalled();
     expect(second.apply).toHaveBeenCalled();

--- a/spec/redirect.spec.ts
+++ b/spec/redirect.spec.ts
@@ -6,7 +6,7 @@ import { redirectMiddleware } from '../lib/redirect';
 import { Location } from '../lib/location';
 
 describe('Redirect Middleware', function() {
-  let redirect: Middleware;
+  let redirect: Middleware<NextInstruction>;
   let routeSet$: Subject<NextInstruction>;
   let location = { replaceState(next: string) { } };
   let observer = { next() { } };


### PR DESCRIPTION
Change `Middleware` interface to accept a generic type. Updates all internal uses of `Middleware` to be typed. Updated internal compose function to accept typed functions.

BREAKING CHANGE: `createMiddleware` now requires a type to be passed to it.

  Before:

  ```ts
  const redirect = createMiddleware(...);
  ```

  After:

  ```ts
  const redirect = createMiddleware<NextInstruction>(..);
  ```