### PR TITLE
refactor(location): Renamed Location service to Router

### DIFF
--- a/docs/overview/guards.md
+++ b/docs/overview/guards.md
@@ -53,7 +53,7 @@ Guards are run before the component or children are loaded. This prevents the us
 While a guard must always return an observable, if a guard dispatches a route change (for instance redirecting to a `400 Not Authorized` route) the current traversal will be immediately canceled:
 
 ```ts
-const authGuard = createGuard(function(http: Http, location: Location) {
+const authGuard = createGuard(function(http: Http, router: Router) {
   // Guards are provided with the route that is being evaluated:
   return function(route: Route) {
     return http.get('/auth/check')
@@ -61,7 +61,7 @@ const authGuard = createGuard(function(http: Http, location: Location) {
       .map(() => true)
       // If request fails, redirect to "not authorized" route
       .catch(() => {
-        location.replaceState('/not-authorized');
+        router.replace('/not-authorized');
         return Observable.of(false);
       });
   }

--- a/docs/overview/params.md
+++ b/docs/overview/params.md
@@ -47,7 +47,7 @@ To demonstrate how to work around this, lets take the above `PostPage` component
 ```ts
 import { Observable } from 'rxjs/Observable';
 import { Http } from 'angular2/http';
-import { RouteParams, Location } from '@ngrx/router';
+import { RouteParams, Router } from '@ngrx/router';
 
 @Component({
   selector: 'post-page',
@@ -60,7 +60,7 @@ export class PostPage {
   post$: Observable<Post>;
   loading: boolean;
 
-  constructor(params$: RouteParams, http: Http) {
+  constructor(params$: RouteParams, http: Http, router: Router) {
     // Listen for the ID to change
     this.post$ = params$.pluck('id')
       // only update if `id` changes
@@ -79,7 +79,7 @@ export class PostPage {
           })
           // If the request fails, go to the 404 route
           .catch(err => {
-            location.replaceState('/404');
+            router.replace('/404');
             return Observable.of(false);
           })
       });

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,7 +2,7 @@ import { Provider, provide } from 'angular2/core';
 import { LocationStrategy } from 'angular2/src/router/location/location_strategy';
 import { PathLocationStrategy } from 'angular2/src/router/location/path_location_strategy';
 
-import { LOCATION_PROVIDERS } from './location';
+import { ROUTER_PROVIDERS } from './router';
 import { ROUTE_SET_PROVIDERS } from './router-instruction';
 import { ROUTE_VIEW_PROVIDERS } from './route-view';
 import { REDIRECT_PROVIDERS } from './redirect';
@@ -23,22 +23,22 @@ export function provideRouter(routes: Routes) {
     GUARD_PROVIDERS,
     LINK_ACTIVE_PROVIDERS,
     LINK_TO_PROVIDERS,
-    LOCATION_PROVIDERS,
     MATCH_ROUTE_PROVIDERS,
     PARAMS_PROVIDERS,
     REDIRECT_PROVIDERS,
     RESOURCE_LOADER_PROVIDERS,
     ROUTE_SET_PROVIDERS,
-    ROUTE_VIEW_PROVIDERS
+    ROUTE_VIEW_PROVIDERS,
+    ROUTER_PROVIDERS
   ];
 }
 
 
 export { Guard, createGuard } from './guard';
-export { LocationChange, Location } from './location';
+export { LocationChange, Router } from './router';
 export { Middleware, createMiddleware } from './middleware';
 export { RouteParams, QueryParams } from './params';
-export { useLocationMiddleware, useRouterInstructionMiddleware, RouterInstruction, NextInstruction } from './router-instruction';
+export { useRouterMiddleware, useRouterInstructionMiddleware, RouterInstruction, NextInstruction } from './router-instruction';
 export { usePreRenderMiddleware, usePostRenderMiddleware, RenderInstruction } from './component-renderer';
 export { Routes, Route, IndexRoute } from './route';
 export { useTraversalMiddleware, TraversalCandidate } from './route-traverser';

--- a/lib/link-active.ts
+++ b/lib/link-active.ts
@@ -12,7 +12,7 @@ import {
   Renderer
 } from 'angular2/core';
 import { LinkTo } from './link-to';
-import { Location } from './location';
+import { Router } from './router';
 
 export interface LinkActiveOptions {
   exact: boolean;
@@ -37,13 +37,13 @@ export interface LinkActiveOptions {
    constructor(
      @Query(LinkTo) public links: QueryList<LinkTo>,
      public element: ElementRef,
-     public location$: Location,
+     public router$: Router,
      public renderer: Renderer
    ) {}
 
    ngAfterViewInit() {
-     this._sub = this.location$
-     .map(({path}) => this.location$.prepareExternalUrl(path))
+     this._sub = this.router$
+     .map(({path}) => this.router$.prepareExternalUrl(path))
      .subscribe(path => {
        this.checkActive(path);
      });

--- a/lib/link-to.ts
+++ b/lib/link-to.ts
@@ -7,12 +7,12 @@ import {
   provide,
   Provider
 } from  'angular2/core';
-import { Location } from './location';
+import { Router } from './router';
 
 /**
  * The LinkTo directive links to routes in your app
  *
- * Links are pushed to the `Location` service to trigger a route change.
+ * Links are pushed to the `Router` service to trigger a route change.
  * Query params can be represented as an object or a string of names/values
  *
  * <a linkTo="/home/page" [queryParams]="{ id: 123 }">Home Page</a>
@@ -36,7 +36,7 @@ export class LinkTo {
   private _href: string;
   private _query: string | Object;
 
-  constructor(private _location: Location) {}
+  constructor(private _router: Router) {}
 
   /**
    * Handles click events on the associated link
@@ -45,14 +45,14 @@ export class LinkTo {
   @HostListener('click', ['$event'])
   onClick(event) {
     if (!this._comboClick(event) && !this.target) {
-      this._location.go(this._href, this._query);
+      this._router.go(this._href, this._query);
 
       event.preventDefault();
     }
   }
 
   private _updateHref() {
-    this.linkHref = this._location.prepareExternalUrl(this._href, this._query);
+    this.linkHref = this._router.prepareExternalUrl(this._href, this._query);
   }
 
   /**

--- a/lib/redirect.ts
+++ b/lib/redirect.ts
@@ -5,27 +5,27 @@
 import { Observable } from 'rxjs/Observable';
 import { Provider } from 'angular2/core';
 
-import { Location } from './location';
+import { Router } from './router';
 import { Routes, Route } from './route';
 import { useRouterInstructionMiddleware, RouterInstruction, NextInstruction } from './router-instruction';
 import { createMiddleware } from './middleware';
 import { formatPattern } from './match-pattern';
 
-export const redirectMiddleware = createMiddleware(function(location: Location) {
+export const redirectMiddleware = createMiddleware(function(router: Router) {
   return (next$: RouterInstruction): RouterInstruction => next$
     .filter(next => {
       const last = next.routeConfigs[next.routeConfigs.length - 1];
 
       if ( !!last.redirectTo ) {
-        handleRedirect(location, last, next);
+        handleRedirect(router, last, next);
         return false;
       }
 
       return true;
     });
-}, [ Location ]);
+}, [ Router ]);
 
-function handleRedirect(location: Location, route: Route, next: NextInstruction) {
+function handleRedirect(router: Router, route: Route, next: NextInstruction) {
   const { routeParams, queryParams } = next;
 
   let pathname;
@@ -40,7 +40,7 @@ function handleRedirect(location: Location, route: Route, next: NextInstruction)
     pathname = formatPattern(pattern, routeParams);
   }
 
-  location.replaceState(pathname, queryParams);
+  router.replace(pathname, queryParams);
 }
 
 function getRoutePattern(routes: Routes, routeIndex: number) {

--- a/lib/router-instruction.ts
+++ b/lib/router-instruction.ts
@@ -14,21 +14,21 @@ import { provide, Provider, Injector, OpaqueToken } from 'angular2/core';
 import { parse as parseQueryString } from 'query-string';
 
 import { compose } from './util';
-import { Location, LocationChange } from './location';
+import { Router, LocationChange } from './router';
 import { Routes, Route, ROUTES } from './route';
 import { RouteTraverser, Match } from './route-traverser';
 import { Middleware, provideMiddlewareForToken, identity } from './middleware';
 
-const LOCATION_MIDDLEWARE = new OpaqueToken(
-  '@ngrx/router Location Middleware'
+const ROUTER_MIDDLEWARE = new OpaqueToken(
+  '@ngrx/router Router Middleware'
 );
 
 const ROUTER_INSTRUCTION_MIDDLEWARE = new OpaqueToken(
   '@ngrx/router Router Instruction Middleware'
 );
 
-export const useLocationMiddleware = provideMiddlewareForToken(
-  LOCATION_MIDDLEWARE
+export const useRouterMiddleware = provideMiddlewareForToken(
+  ROUTER_MIDDLEWARE
 );
 
 export const useRouterInstructionMiddleware = provideMiddlewareForToken(
@@ -47,12 +47,12 @@ export class RouterInstruction extends Observable<NextInstruction> { }
 
 
 function createRouterInstruction(
-  location$: Location,
+  router$: Router,
   traverser: RouteTraverser,
   locationMiddleware: Middleware[],
   routerInstructionMiddleware: Middleware[]
 ): RouterInstruction {
-  return location$
+  return router$
     .observeOn(queue)
     .distinctUntilChanged((prev, next) => prev.path === next.path)
     .let<LocationChange>(compose(...locationMiddleware))
@@ -78,9 +78,9 @@ function createRouterInstruction(
 
 export const ROUTE_SET_PROVIDERS = [
   provide(RouterInstruction, {
-    deps: [ Location, RouteTraverser, LOCATION_MIDDLEWARE, ROUTER_INSTRUCTION_MIDDLEWARE ],
+    deps: [ Router, RouteTraverser, ROUTER_MIDDLEWARE, ROUTER_INSTRUCTION_MIDDLEWARE ],
     useFactory: createRouterInstruction
   }),
-  useLocationMiddleware(identity),
+  useRouterMiddleware(identity),
   useRouterInstructionMiddleware(identity)
 ];

--- a/lib/router.ts
+++ b/lib/router.ts
@@ -16,48 +16,8 @@ export interface LocationChange {
   type: 'push' | 'pop' | 'replace';
 }
 
-/**
- * `Location` is a service that applications can use to interact with a browser's URL.
- * Depending on which {@link LocationStrategy} is used, `Location` will either persist
- * to the URL's path or the URL's hash segment.
- *
- * Note: it's better to use {@link Router#navigate} service to trigger route changes. Use
- * `Location` only if you need to interact with or create normalized URLs outside of
- * routing.
- *
- * `Location` is responsible for normalizing the URL against the application's base href.
- * A normalized URL is absolute from the URL host, includes the application's base href, and has no
- * trailing slash:
- * - `/my/app/user/123` is normalized
- * - `my/app/user/123` **is not** normalized
- * - `/my/app/user/123/` **is not** normalized
- *
- * ### Example
- *
- * ```
- * import {Component} from 'angular2/core';
- * import {
- *   ROUTER_DIRECTIVES,
- *   ROUTER_PROVIDERS,
- *   RouteConfig,
- *   Location
- * } from 'angular2/router';
- *
- * @Component({directives: [ROUTER_DIRECTIVES]})
- * @RouteConfig([
- *  {...},
- * ])
- * class AppCmp {
- *   constructor(location: Location) {
- *     location.go('/foo');
- *   }
- * }
- *
- * bootstrap(AppCmp, [ROUTER_PROVIDERS]);
- * ```
- */
 @Injectable()
-export class Location extends ReplaySubject<LocationChange> {
+export class Router extends ReplaySubject<LocationChange> {
   private _baseHref: string;
 
   constructor(public platformStrategy: LocationStrategy) {
@@ -115,19 +75,19 @@ export class Location extends ReplaySubject<LocationChange> {
    * Changes the browsers URL to the normalized version of the given URL, and replaces
    * the top item on the platform's history stack.
    */
-  replaceState(path: string, query: any = ''): void {
+  replace(path: string, query: any = ''): void {
     this.platformStrategy.replaceState(null, '', path, normalizeQuery(query));
     this._update('replace');
   }
 
   /**
-   * Changes the browsers query parameters. Replaces teh top item on the platform's
+   * Changes the browsers query parameters. Replaces the top item on the platform's
    * history stack
    */
    search(query: any = ''): void {
      const [ pathname ] = this.path().split('?');
 
-     this.replaceState(pathname, query);
+     this.replace(pathname, query);
    }
 
   /**
@@ -175,7 +135,7 @@ function normalizeQueryParams(params: string): string {
   return (params.length > 0 && params.substring(0, 1) !== '?') ? ('?' + params) : params;
 }
 
-export const LOCATION_PROVIDERS = [
-  provide(Location, { useClass: Location }),
+export const ROUTER_PROVIDERS = [
+  provide(Router, { useClass: Router }),
   provide(PlatformLocation, { useClass: BrowserPlatformLocation })
 ];

--- a/spec/component-renderer.spec.ts
+++ b/spec/component-renderer.spec.ts
@@ -4,7 +4,7 @@ import { Observable } from 'rxjs/Observable';
 import { Injector, provide, DynamicComponentLoader, ElementRef } from 'angular2/core';
 
 import { RESOURCE_LOADER_PROVIDERS } from '../lib/resource-loader';
-import { Location } from '../lib/location';
+
 import {
   ComponentRenderer,
   usePreRenderMiddleware,

--- a/spec/link-active.spec.ts
+++ b/spec/link-active.spec.ts
@@ -14,7 +14,7 @@ import {
 } from 'angular2/core';
 import { LinkTo } from '../lib/link-to';
 import { LinkActive } from '../lib/link-active';
-import { LOCATION_PROVIDERS, Location } from '../lib/location';
+import { ROUTER_PROVIDERS, Router } from '../lib/router';
 import { SpyLocation } from 'angular2/router/testing';
 import { Observable } from 'rxjs/Observable';
 import { BehaviorSubject } from 'rxjs/subject/BehaviorSubject';
@@ -36,7 +36,7 @@ const compile = (tcb: TestComponentBuilder, template: string = '') => {
 
 describe('Link Active', () => {
   beforeEachProviders(() => [
-    LOCATION_PROVIDERS,
+    ROUTER_PROVIDERS,
     provide(LocationStrategy, { useClass: MockLocationStrategy })
   ]);
 
@@ -44,8 +44,8 @@ describe('Link Active', () => {
     expect(LinkActive).toBeDefined();
   });
 
-  it('should add the provided class to the active element', injectAsync([TestComponentBuilder, Location], (tcb, location$) => {
-    location$.next({
+  it('should add the provided class to the active element', injectAsync([TestComponentBuilder, Router], (tcb, router$) => {
+    router$.next({
       path: '/page'
     });
 
@@ -59,8 +59,8 @@ describe('Link Active', () => {
       });
   }));
 
-  it('should support multiple classes on the active element', injectAsync([TestComponentBuilder, Location], (tcb, location$) => {
-    location$.next({
+  it('should support multiple classes on the active element', injectAsync([TestComponentBuilder, Router], (tcb, router$) => {
+    router$.next({
       path: '/page'
     });
 
@@ -74,8 +74,8 @@ describe('Link Active', () => {
       });
   }));
 
-  it('should add the provided class to a child element', injectAsync([TestComponentBuilder, Location], (tcb, location$) => {
-    location$.next({
+  it('should add the provided class to a child element', injectAsync([TestComponentBuilder, Router], (tcb, router$) => {
+    router$.next({
       path: '/page'
     });
 
@@ -93,8 +93,8 @@ describe('Link Active', () => {
       });
   }));
 
-  it('should add the provided class to a parent element with one active child element', injectAsync([TestComponentBuilder, Location], (tcb, location$) => {
-    location$.next({
+  it('should add the provided class to a parent element with one active child element', injectAsync([TestComponentBuilder, Router], (tcb, router$) => {
+    router$.next({
       path: '/page2'
     });
 
@@ -114,8 +114,8 @@ describe('Link Active', () => {
       });
   }));
 
-  it('should match parent/child elements when using non-exact match', injectAsync([TestComponentBuilder, Location], (tcb, location$) => {
-    location$.next({
+  it('should match parent/child elements when using non-exact match', injectAsync([TestComponentBuilder, Router], (tcb, router$) => {
+    router$.next({
       path: '/pages/page2'
     });
 
@@ -134,7 +134,7 @@ describe('Link Active', () => {
       });
   }));
 
-  it('should only check path for active link', injectAsync([TestComponentBuilder, Location], (tcb, location$) => {
+  it('should only check path for active link', injectAsync([TestComponentBuilder, Router], (tcb, router$) => {
     return compile(tcb, `
           <a linkActive="active" linkTo="/pages/page2" [queryParams]="{ search: 'criteria' }">Page 2</a><br>
       `)
@@ -143,7 +143,7 @@ describe('Link Active', () => {
         let compiled = fixture.debugElement.nativeElement;
         let link: Element = compiled.querySelector('a');
 
-        location$.next({
+        router$.next({
           path: '/pages/page2'
         });
 

--- a/spec/link-to.spec.ts
+++ b/spec/link-to.spec.ts
@@ -10,7 +10,7 @@ import {
 } from 'angular2/testing';
 import { Component, provide, ViewChild } from 'angular2/core';
 import { LinkTo } from '../lib/link-to';
-import { LOCATION_PROVIDERS, Location } from '../lib/location';
+import { ROUTER_PROVIDERS, Router } from '../lib/router';
 import { Observable } from 'rxjs/Observable';
 import { LocationStrategy } from 'angular2/src/router/location/location_strategy';
 import { MockLocationStrategy } from 'angular2/src/mock/mock_location_strategy';
@@ -32,7 +32,7 @@ const compile = (tcb: TestComponentBuilder, template: string = '') => {
 
 describe('Link To', () => {
   beforeEachProviders(() => [
-    LOCATION_PROVIDERS,
+    ROUTER_PROVIDERS,
     provide(LocationStrategy, { useClass: MockLocationStrategy })
   ]);
 
@@ -74,7 +74,7 @@ describe('Link To', () => {
   }));
 
   describe('When Clicked', () => {
-    it('should go to the provided URL', injectAsync([TestComponentBuilder, Location], (tcb, location) => {
+    it('should go to the provided URL', injectAsync([TestComponentBuilder, Router], (tcb, router) => {
       let linkHref = '/page';
       let queryParams = '{id: 1}';
 
@@ -84,15 +84,15 @@ describe('Link To', () => {
           let compiled = fixture.debugElement.nativeElement;
           let link = compiled.querySelector('a');
 
-          spyOn(location, 'go');
+          spyOn(router, 'go');
 
           link.click();
 
-          expect(location.go).toHaveBeenCalledWith(linkHref, queryParams);
+          expect(router.go).toHaveBeenCalledWith(linkHref, queryParams);
         });
     }));
 
-    it('should not prevent default behavior with a provided target', injectAsync([TestComponentBuilder, Location], (tcb, location) => {
+    it('should not prevent default behavior with a provided target', injectAsync([TestComponentBuilder, Router], (tcb, router) => {
       let linkHref = '/page';
       let queryParams = 'id=1';
 
@@ -102,17 +102,17 @@ describe('Link To', () => {
           let compiled = fixture.debugElement.nativeElement;
           let link = compiled.querySelector('a');
 
-          spyOn(location, 'go');
+          spyOn(router, 'go');
 
           let instance = fixture.componentInstance.link;
           let event = { button: 1 };
           instance.onClick(event);
 
-          expect(location.go).not.toHaveBeenCalled();
+          expect(router.go).not.toHaveBeenCalled();
         });
     }));
 
-    it('should not prevent default behavior with a combo click', injectAsync([TestComponentBuilder, Location], (tcb, location) => {
+    it('should not prevent default behavior with a combo click', injectAsync([TestComponentBuilder, Router], (tcb, router) => {
       let linkHref = '/page';
       let queryParams = 'id=1';
 
@@ -125,7 +125,7 @@ describe('Link To', () => {
 
           let instance = fixture.componentInstance.link;
 
-          spyOn(location, 'go');
+          spyOn(router, 'go');
 
           let events = [
             { which: 1, ctrlKey: true },
@@ -142,7 +142,7 @@ describe('Link To', () => {
             instance.onClick(event);
           });
 
-          expect(location.go.calls.count()).toEqual(0);
+          expect(router.go.calls.count()).toEqual(0);
         });
     }));
   });

--- a/spec/redirect.spec.ts
+++ b/spec/redirect.spec.ts
@@ -3,12 +3,12 @@ import { Injector, provide } from 'angular2/core';
 import { NextInstruction } from '../lib/router-instruction';
 import { Middleware } from '../lib/middleware';
 import { redirectMiddleware } from '../lib/redirect';
-import { Location } from '../lib/location';
+import { Router } from '../lib/router';
 
 describe('Redirect Middleware', function() {
   let redirect: Middleware;
   let routeSet$: Subject<NextInstruction>;
-  let location = { replaceState(next: string) { } };
+  let router = { replace(next: string) { } };
   let observer = { next() { } };
 
   function nextInstruction(to: string, routeParams: any = {}, queryParams: any = {}) {
@@ -25,10 +25,10 @@ describe('Redirect Middleware', function() {
 
   beforeEach(function() {
     routeSet$ = new Subject<NextInstruction>();
-    spyOn(location, 'replaceState');
+    spyOn(router, 'replace');
     spyOn(observer, 'next');
     const injector = Injector.resolveAndCreate([
-      provide(Location, { useValue: location })
+      provide(Router, { useValue: router })
     ]);
 
     redirect = injector.resolveAndInstantiate(redirectMiddleware);
@@ -63,7 +63,7 @@ describe('Redirect Middleware', function() {
     nextInstruction('/test');
 
     expect(observer.next).not.toHaveBeenCalled();
-    expect(location.replaceState).toHaveBeenCalledWith('/test', {});
+    expect(router.replace).toHaveBeenCalledWith('/test', {});
   });
 
   it('should correctly redirect paths with params', function() {
@@ -72,7 +72,7 @@ describe('Redirect Middleware', function() {
     nextInstruction('/posts/:id', { id: '543' });
 
     expect(observer.next).not.toHaveBeenCalled();
-    expect(location.replaceState).toHaveBeenCalledWith('/posts/543', {});
+    expect(router.replace).toHaveBeenCalledWith('/posts/543', {});
   });
 
   it('should redirect relative paths', function() {
@@ -89,7 +89,7 @@ describe('Redirect Middleware', function() {
     });
 
     expect(observer.next).not.toHaveBeenCalled();
-    expect(location.replaceState).toHaveBeenCalledWith('/home', {});
+    expect(router.replace).toHaveBeenCalledWith('/home', {});
   });
 
   it('should redirect relative paths with params', function() {
@@ -106,6 +106,6 @@ describe('Redirect Middleware', function() {
     });
 
     expect(observer.next).not.toHaveBeenCalled();
-    expect(location.replaceState).toHaveBeenCalledWith('/posts/543', {});
+    expect(router.replace).toHaveBeenCalledWith('/posts/543', {});
   });
 });

--- a/spec/route-set.spec.ts
+++ b/spec/route-set.spec.ts
@@ -6,7 +6,7 @@ import { LocationStrategy } from 'angular2/src/router/location/location_strategy
 import { MockLocationStrategy } from 'angular2/src/mock/mock_location_strategy';
 
 import { RouteTraverser } from '../lib/route-traverser';
-import { Location, LOCATION_PROVIDERS } from '../lib/location';
+import { Router, ROUTER_PROVIDERS } from '../lib/router';
 import { NextInstruction, RouterInstruction, ROUTE_SET_PROVIDERS } from '../lib/router-instruction';
 
 
@@ -16,7 +16,7 @@ describe('Route Set', function() {
 
   let mockTraverser: any;
   let routerInstruction: RouterInstruction;
-  let location: Location;
+  let router: Router;
 
   beforeEach(function() {
     mockTraverser = {
@@ -28,21 +28,21 @@ describe('Route Set', function() {
     spyOn(mockTraverser, 'find').and.callThrough();
 
     const injector = Injector.resolveAndCreate([
-      LOCATION_PROVIDERS,
+      ROUTER_PROVIDERS,
       ROUTE_SET_PROVIDERS,
       provide(RouteTraverser, { useValue: mockTraverser }),
       provide(LocationStrategy, { useClass: MockLocationStrategy })
     ]);
 
     routerInstruction = injector.get(RouterInstruction);
-    location = injector.get(Location);
+    router = injector.get(Router);
   });
 
   it('should parse a simple location change into a new route set', function(done) {
-    location.go('/test');
+    router.go('/test');
 
     routerInstruction
-      .withLatestFrom(location)
+      .withLatestFrom(router)
       .subscribe(([set, change]) => {
         expect(set.routeConfigs).toBe(routes);
         expect(set.routeParams).toBe(params);
@@ -55,7 +55,7 @@ describe('Route Set', function() {
   });
 
   it('should parse a location change with query params', function(done) {
-    location.go('/test?a=2');
+    router.go('/test?a=2');
 
     routerInstruction.subscribe(set => {
       expect(set.queryParams.a).toBeDefined();
@@ -66,7 +66,7 @@ describe('Route Set', function() {
   });
 
   it('should share a subscription amonst all subscribers', function() {
-    location.go('/');
+    router.go('/');
 
     routerInstruction.subscribe();
     routerInstruction.subscribe();

--- a/spec/router.spec.ts
+++ b/spec/router.spec.ts
@@ -16,42 +16,42 @@ import {
 import {Injector, provide} from 'angular2/core';
 import {CONST_EXPR} from 'angular2/src/facade/lang';
 
-import {Location} from '../lib/location';
+import {Router} from '../lib/router';
 import {LocationStrategy, APP_BASE_HREF} from 'angular2/src/router/location/location_strategy';
 import {MockLocationStrategy} from 'angular2/src/mock/mock_location_strategy';
 
-describe('Location', () => {
+describe('Router', () => {
 
-  let locationStrategy, location;
+  let locationStrategy, router: Router;
 
-  function makeLocation(baseHref: string = '/my/app', provider: any = CONST_EXPR([])): Location {
+  function makeRouter(baseHref: string = '/my/app', provider: any = CONST_EXPR([])): Router {
     locationStrategy = new MockLocationStrategy();
     locationStrategy.internalBaseHref = baseHref;
     let injector = Injector.resolveAndCreate(
-        [Location, provide(LocationStrategy, {useValue: locationStrategy}), provider]);
-    return location = injector.get(Location);
+        [Router, provide(LocationStrategy, {useValue: locationStrategy}), provider]);
+    return router = injector.get(Router);
   }
 
   beforeEach(() => {
-    makeLocation();
+    makeRouter();
   });
 
   it('should not prepend urls with starting slash when an empty URL is provided',
-     () => { expect(location.prepareExternalUrl('')).toEqual(locationStrategy.getBaseHref()); });
+     () => { expect(router.prepareExternalUrl('')).toEqual(locationStrategy.getBaseHref()); });
 
   it('should not prepend path with an extra slash when a baseHref has a trailing slash', () => {
-    let location = makeLocation('/my/slashed/app/');
-    expect(location.prepareExternalUrl('/page')).toEqual('/my/slashed/app/page');
+    let router = makeRouter('/my/slashed/app/');
+    expect(router.prepareExternalUrl('/page')).toEqual('/my/slashed/app/page');
   });
 
   it('should not append urls with leading slash on navigate', () => {
-    location.go('/my/app/user/btford');
+    router.go('/my/app/user/btford');
     expect(locationStrategy.path()).toEqual('/my/app/user/btford');
   });
 
   xit('should normalize urls on popstate', (done) => {
      locationStrategy.simulatePopState('/my/app/user/btford');
-     location.subscribe((ev) => {
+     router.subscribe((ev) => {
        expect(ev['url']).toEqual('/user/btford');
        done();
      });
@@ -59,74 +59,74 @@ describe('Location', () => {
 
   it('should revert to the previous path when a back() operation is executed', () => {
     let locationStrategy = new MockLocationStrategy();
-    let location = new Location(locationStrategy);
+    let router = new Router(locationStrategy);
 
-    function assertUrl(path) { expect(location.path()).toEqual(path); }
+    function assertUrl(path) { expect(router.path()).toEqual(path); }
 
-    location.go('/ready');
+    router.go('/ready');
     assertUrl('/ready');
 
-    location.go('/ready/set');
+    router.go('/ready/set');
     assertUrl('/ready/set');
 
-    location.go('/ready/set/go');
+    router.go('/ready/set/go');
     assertUrl('/ready/set/go');
 
-    location.back();
+    router.back();
     assertUrl('/ready/set');
 
-    location.back();
+    router.back();
     assertUrl('/ready');
   });
 
   it('should incorporate the provided query values into the location change', () => {
     let locationStrategy = new MockLocationStrategy();
-    let location = new Location(locationStrategy);
+    let router = new Router(locationStrategy);
 
-    location.go('/home', 'key=value');
-    expect(location.path()).toEqual('/home?key=value');
+    router.go('/home', 'key=value');
+    expect(router.path()).toEqual('/home?key=value');
 
-    location.go('/home', { foo: 'bar' });
-    expect(location.path()).toEqual('/home?foo=bar');
+    router.go('/home', { foo: 'bar' });
+    expect(router.path()).toEqual('/home?foo=bar');
   });
 
   it('should allow you to replace query params', () => {
     let locationStrategy = new MockLocationStrategy();
-    let location = new Location(locationStrategy);
+    let router = new Router(locationStrategy);
 
-    location.go('/home');
-    location.search('key=value');
-    expect(location.path()).toEqual('/home?key=value');
+    router.go('/home');
+    router.search('key=value');
+    expect(router.path()).toEqual('/home?key=value');
 
-    location.search({ foo: 'bar' });
-    expect(location.path()).toEqual('/home?foo=bar');
+    router.search({ foo: 'bar' });
+    expect(router.path()).toEqual('/home?foo=bar');
   });
 
   it('should replace the state when using search to update query params', () => {
     let locationStrategy = new MockLocationStrategy();
-    let location = new Location(locationStrategy);
+    let router = new Router(locationStrategy);
 
-    location.go('/home');
+    router.go('/home');
 
-    spyOn(location, 'replaceState');
-    spyOn(location, 'go');
+    spyOn(router, 'replace');
+    spyOn(router, 'go');
 
-    location.search('key=value');
-    expect(location.go).not.toHaveBeenCalled();
-    expect(location.replaceState).toHaveBeenCalledWith('/home', 'key=value');
+    router.search('key=value');
+    expect(router.go).not.toHaveBeenCalled();
+    expect(router.replace).toHaveBeenCalledWith('/home', 'key=value');
   });
 
   it('should update subject on location update', (done) => {
-    location.go('/update/path');
-    location.subscribe((ev) => {
+    router.go('/update/path');
+    router.subscribe((ev) => {
       expect(ev.path).toEqual('/update/path');
       done();
     });
   });
 
-  it('should update subject on location replaceState', (done) => {
-    location.replaceState('/replace/path');
-    location.subscribe((ev) => {
+  it('should update subject on location replace', (done) => {
+    router.replace('/replace/path');
+    router.subscribe((ev) => {
       expect(ev.path).toEqual('/replace/path');
       done();
     });

--- a/spec/tsconfig.json
+++ b/spec/tsconfig.json
@@ -19,7 +19,6 @@
     "./index.spec.ts",
     "./link-active.spec.ts",
     "./link-to.spec.ts",
-    "./location.spec.ts",
     "./match-pattern.spec.ts",
     "./middleware.spec.ts",
     "./params.spec.ts",
@@ -28,6 +27,7 @@
     "./route-traverser.spec.ts",
     "./route-view.spec.ts",
     "./route.spec.ts",
+    "./router.spec.ts",
     "./util.spec.ts",
     "../typings/main.d.ts"
   ],


### PR DESCRIPTION
BREAKING CHANGE: Renamed `Location` service to `Router` and renamed `replaceState` method to `replace`

Before:
```ts
import { Location } from '@ngrx/router';

class App {
    constructor(location: Location) {
        location.replaceState('/path', { query: 1 });
    }
}
```

After:
```ts
import { Router } from '@ngrx/router';

class App {
    constructor(router: Router) {
        router.replace('/path', { query: 1 });
    }
}
```