### PR TITLE
refactor(Guards): Improve guards API based on common usage

### DIFF
--- a/lib/guard.ts
+++ b/lib/guard.ts
@@ -23,10 +23,10 @@ import { useTraversalMiddleware, TraversalCandidate } from './route-traverser';
 import { createMiddleware } from './middleware';
 
 export interface Guard {
-  (route: Route, params: any, isTerminal: boolean): Observable<boolean>;
+  (params: any, route: Route, isTerminal: boolean): Observable<boolean>;
 }
 
-export const createGuard = createProviderFactory<Guard>('@ngrx/router Guard');
+export const provideGuard = createProviderFactory<Guard>('@ngrx/router Guard');
 
 export const guardMiddleware = createMiddleware(function(injector: Injector) {
   return (route$: Observable<TraversalCandidate>) => route$
@@ -35,7 +35,7 @@ export const guardMiddleware = createMiddleware(function(injector: Injector) {
         const guards: Guard[] = route.guards
           .map(provider => injector.resolveAndInstantiate(provider));
 
-        const resolved = guards.map(guard => guard(route, params, isTerminal));
+        const resolved = guards.map(guard => guard(params, route, isTerminal));
 
         return Observable.merge(...resolved)
           .every(value => !!value)

--- a/spec/guard.spec.ts
+++ b/spec/guard.spec.ts
@@ -5,7 +5,7 @@ import { Injector } from 'angular2/core';
 import { Route } from '../lib/route';
 import { Middleware } from '../lib/middleware';
 import { TraversalCandidate } from '../lib/route-traverser';
-import { Guard, createGuard, guardMiddleware } from '../lib/guard';
+import { Guard, provideGuard, guardMiddleware } from '../lib/guard';
 
 
 describe('Guard Middleware', function() {
@@ -43,7 +43,7 @@ describe('Guard Middleware', function() {
 
   it('should resolve all guards in the context of the injector', function() {
     spyOn(injector, 'resolveAndInstantiate').and.callThrough();
-    const guard = createGuard(() => () => Observable.of(true));
+    const guard = provideGuard(() => () => Observable.of(true));
 
     route({ guards: [ guard ] }).let(guardRunner).subscribe();
 
@@ -53,18 +53,18 @@ describe('Guard Middleware', function() {
   it('should provide guards with the route it has matched', function() {
     const testGuard = { run: () => Observable.of(true) };
     spyOn(testGuard, 'run').and.callThrough();
-    const guard = createGuard(() => testGuard.run);
+    const guard = provideGuard(() => testGuard.run);
     const nextRoute = { guards: [ guard ] };
     const params = { abc: 123 };
     const isTerminal = true;
 
     route(nextRoute, params, isTerminal).let(guardRunner).subscribe();
 
-    expect(testGuard.run).toHaveBeenCalledWith(nextRoute, params, isTerminal);
+    expect(testGuard.run).toHaveBeenCalledWith(params, nextRoute, isTerminal);
   });
 
   it('should return true if all of the guards return true', function(done) {
-    const pass = createGuard(() => () => Observable.of(true));
+    const pass = provideGuard(() => () => Observable.of(true));
 
     route({ guards: [ pass ] })
       .let<TraversalCandidate>(guardRunner)
@@ -76,8 +76,8 @@ describe('Guard Middleware', function() {
   });
 
   it('should return false if just one guard returns false', function(done) {
-    const pass = createGuard(() => () => Observable.of(true));
-    const fail = createGuard(() => () => Observable.of(false));
+    const pass = provideGuard(() => () => Observable.of(true));
+    const fail = provideGuard(() => () => Observable.of(false));
 
     route({ guards: [ pass, fail ] })
       .let(guardRunner)


### PR DESCRIPTION
Change guard factory from `createGuard` to `provideGuard` to clarify what the factory is doing. Re-order guard params to receive route params first.

BREAKING CHANGE:

  Before:
  ```ts
  const auth = createGuard(function(http: Http) {

    return function(route: Route, params: any, isTerminal: boolean) {
      return http.get(...);
    };

  }, [ Http ]);
  ```

  After:
  ```ts
  const auth = provideGuard(function(http: Http) {

    return function(params: any, route: Route, isTerminal: boolean) {
      return http.get(...);
    };

  }, [ Http ]);
  ```