### PR TITLE
fix(RouterInstruction): Pass the subscriber back through NgZone

### DIFF
--- a/lib/zone.ts
+++ b/lib/zone.ts
@@ -1,0 +1,22 @@
+import { NgZone } from 'angular2/core';
+import { Operator } from 'rxjs/Operator';
+import { Subscriber } from 'rxjs/Subscriber';
+
+
+export class ZoneOperator<T> implements Operator<T, T> {
+  constructor(private _zone: NgZone) { }
+
+  call(subscriber: Subscriber<T>): Subscriber<T> {
+    return new ZoneSubscriber(subscriber, this._zone);
+  }
+}
+
+class ZoneSubscriber<T> extends Subscriber<T> {
+  constructor(destination: Subscriber<T>, private _zone: NgZone) {
+    super(destination);
+  }
+
+  protected _next(value: T) {
+    this._zone.run(() => this.destination.next(value));
+  }
+}

--- a/spec/router-instruction.spec.ts
+++ b/spec/router-instruction.spec.ts
@@ -1,5 +1,5 @@
 import 'rxjs/add/operator/withLatestFrom';
-import { Injector, provide } from 'angular2/core';
+import { Injector, provide, NgZone } from 'angular2/core';
 import { Subject } from 'rxjs/Subject';
 import { Observable } from 'rxjs/Observable';
 import { LocationStrategy } from 'angular2/src/router/location/location_strategy';
@@ -15,6 +15,7 @@ describe('Route Set', function() {
   const routes = ['a', 'c', 'c'];
 
   let mockTraverser: any;
+  let mockZone: any;
   let routerInstruction: RouterInstruction;
   let router: Router;
 
@@ -25,13 +26,21 @@ describe('Route Set', function() {
       }
     };
 
+    mockZone = {
+      run(fn) {
+        return fn();
+      }
+    };
+
     spyOn(mockTraverser, 'find').and.callThrough();
+    spyOn(mockZone, 'run').and.callThrough();
 
     const injector = Injector.resolveAndCreate([
       ROUTER_PROVIDERS,
       ROUTE_SET_PROVIDERS,
       provide(RouteTraverser, { useValue: mockTraverser }),
-      provide(LocationStrategy, { useClass: MockLocationStrategy })
+      provide(LocationStrategy, { useClass: MockLocationStrategy }),
+      provide(NgZone, { useValue: mockZone })
     ]);
 
     routerInstruction = injector.get(RouterInstruction);
@@ -71,6 +80,16 @@ describe('Route Set', function() {
     routerInstruction.subscribe();
     routerInstruction.subscribe(() => {
       expect(mockTraverser.find).toHaveBeenCalledTimes(1);
+
+      done();
+    });
+  });
+
+  it('should pass the subscription back into the Angular zone', function(done) {
+    router.go('/');
+
+    routerInstruction.subscribe(() => {
+      expect(mockZone.run).toHaveBeenCalled();
 
       done();
     });

--- a/spec/tsconfig.json
+++ b/spec/tsconfig.json
@@ -24,7 +24,7 @@
     "./middleware.spec.ts",
     "./params.spec.ts",
     "./redirect.spec.ts",
-    "./route-set.spec.ts",
+    "./router-instruction.spec.ts",
     "./route-traverser.spec.ts",
     "./route-view.spec.ts",
     "./route.spec.ts",


### PR DESCRIPTION
@robwormald Can you take a look at the ZoneOperator and let me know if this is roughly what you were thinking? It uses NgZone to pass values into the destination subscriber.