### PR TITLE
refactor(Guards): Re-implement guards feature to use services

### DIFF
--- a/lib/guard.ts
+++ b/lib/guard.ts
@@ -1,14 +1,14 @@
 /**
- * Guards are simple services that can protect routes from being traversed. They
- * are implemented using traversal middleware
+ * Guards are services that can protect routes from being traversed. They
+ * are implemented using traversal hooks
  *
- * A guard is called when the router begins traversing a route configuration file.
- * It returns `true` or `false` to let the router know if it should consider
- * the route a candidate. Using guards, you can auth protect routes, run data
- * fetching, etc.
+ * A guard's `protectRoute` method is called when the router begins traversing a
+ * route configuration file. It returns `true` or `false` to let the router know
+ * if it should consider the route a candidate. Using guards, you can auth
+ * protect routes, run data fetching, etc.
  *
- * A limitation of guards is that they are instantiated with the _root_ ReflectiveInjector.
- * For more powerful injection, consider looking at render middleware
+ * A limitation of guards is that they must be provided in the same place you
+ * provide the router.
  */
 import 'rxjs/add/observable/merge';
 import 'rxjs/add/observable/of';
@@ -23,36 +23,43 @@ import { TRAVERSAL_HOOKS, TraversalCandidate } from './route-traverser';
 import { Hook } from './hooks';
 
 export interface Guard {
-  (params: any, route: Route, isTerminal: boolean): Observable<boolean>;
+  protectRoute(candidate: TraversalCandidate): Observable<boolean>;
 }
-
-export const provideGuard = createProviderFactory<Guard>('@ngrx/router Guard');
 
 
 @Injectable()
 export class GuardHook implements Hook<TraversalCandidate> {
   constructor(@Inject(Injector) private _injector: ReflectiveInjector) { }
 
-  apply(route$) {
-    return route$.mergeMap(({ route, params, isTerminal }) => {
+  resolveGuard(token: any): Guard {
+    let guard = this._injector.get(token, null);
+
+    if ( guard === null ) {
+      guard = this._injector.resolveAndInstantiate(token);
+    }
+
+    return guard;
+  }
+
+  apply(route$: Observable<TraversalCandidate>): Observable<TraversalCandidate> {
+    return route$.mergeMap(candidate => {
+      const { route } = candidate;
       if ( !!route.guards && Array.isArray(route.guards) && route.guards.length > 0 ) {
-        const guards: Guard[] = route.guards
-          .map(provider => this._injector.resolveAndInstantiate(provider));
+        const guards: Guard[] = route.guards.map(token => this.resolveGuard(token));
+        const activated = guards.map(guard => guard.protectRoute(candidate));
 
-        const resolved = guards.map(guard => guard(params, route, isTerminal));
-
-        return Observable.merge(...resolved)
+        return Observable.merge(...activated)
           .every(value => !!value)
           .map(passed => {
             if ( passed ) {
-              return { route, params, isTerminal };
+              return candidate;
             }
 
-            return { route: null, params, isTerminal };
+            return Object.assign({}, candidate, { route: null });
           });
       }
 
-      return Observable.of({ route, params, isTerminal });
+      return Observable.of(candidate);
     });
   }
 }

--- a/lib/route.ts
+++ b/lib/route.ts
@@ -22,7 +22,7 @@ export interface IndexRoute extends BaseRoute {
 
 export interface Route extends IndexRoute {
   path?: string;
-  guards?: Provider[];
+  guards?: any[];
   indexRoute?: IndexRoute;
   loadIndexRoute?: Async<IndexRoute>;
   children?: Routes;

--- a/spec/guard.spec.ts
+++ b/spec/guard.spec.ts
@@ -4,12 +4,20 @@ import { ReflectiveInjector } from '@angular/core';
 
 import { Route } from '../lib/route';
 import { TraversalCandidate } from '../lib/route-traverser';
-import { Guard, provideGuard, GuardHook } from '../lib/guard';
+import { Guard, GuardHook } from '../lib/guard';
 
 
 describe('Guard Middleware', function() {
   let guardHook: GuardHook;
   let injector: ReflectiveInjector;
+
+  class PassGuard implements Guard {
+    protectRoute = () => Observable.of(true);
+  }
+
+  class FailGuard implements Guard {
+    protectRoute = () => Observable.of(false);
+  }
 
   function route(route: Route, params = {}, isTerminal = false) {
     return Observable.of({ route, params, isTerminal });
@@ -42,30 +50,29 @@ describe('Guard Middleware', function() {
 
   it('should resolve all guards in the context of the injector', function() {
     spyOn(injector, 'resolveAndInstantiate').and.callThrough();
-    const guard = provideGuard(() => () => Observable.of(true));
 
-    route({ guards: [ guard ] }).let(t => guardHook.apply(t)).subscribe();
+    route({ guards: [ PassGuard ] }).let(t => guardHook.apply(t)).subscribe();
 
-    expect(injector.resolveAndInstantiate).toHaveBeenCalledWith(guard);
+    expect(injector.resolveAndInstantiate).toHaveBeenCalledWith(PassGuard);
   });
 
-  it('should provide guards with the route it has matched', function() {
-    const testGuard = { run: () => Observable.of(true) };
-    spyOn(testGuard, 'run').and.callThrough();
-    const guard = provideGuard(() => testGuard.run);
-    const nextRoute = { guards: [ guard ] };
-    const params = { abc: 123 };
-    const isTerminal = true;
-
-    route(nextRoute, params, isTerminal).let(t => guardHook.apply(t)).subscribe();
-
-    expect(testGuard.run).toHaveBeenCalledWith(params, nextRoute, isTerminal);
+  // Intentionally commenting this out because a future PR will refactor
+  // traversal candidate and will pass that to the guards instead
+  xit('should provide guards with the TraversalCandidate', function() {
+    // const testGuard = { run: () => Observable.of(true) };
+    // spyOn(testGuard, 'run').and.callThrough();
+    // const guard = provideGuard(() => testGuard.run);
+    // const nextRoute = { guards: [ guard ] };
+    // const params = { abc: 123 };
+    // const isTerminal = true;
+    //
+    // route(nextRoute, params, isTerminal).let(t => guardHook.apply(t)).subscribe();
+    //
+    // expect(testGuard.run).toHaveBeenCalledWith(params, nextRoute, isTerminal);
   });
 
   it('should return true if all of the guards return true', function(done) {
-    const pass = provideGuard(() => () => Observable.of(true));
-
-    route({ guards: [ pass ] })
+    route({ guards: [ PassGuard ] })
       .let<TraversalCandidate>(t => guardHook.apply(t))
       .subscribe(({ route }) => {
         expect(route).toBeTruthy();
@@ -75,10 +82,7 @@ describe('Guard Middleware', function() {
   });
 
   it('should return false if just one guard returns false', function(done) {
-    const pass = provideGuard(() => () => Observable.of(true));
-    const fail = provideGuard(() => () => Observable.of(false));
-
-    route({ guards: [ pass, fail ] })
+    route({ guards: [ PassGuard, FailGuard ] })
       .let<any>(t => guardHook.apply(t))
       .subscribe(({ route }) => {
         expect(route).toBeFalsy();


### PR DESCRIPTION
Before we used `provideGuard` to quickly create guard factory functions. In order to play better with the offline compiler, this changes guards to instead use traditional services.

BREAKING CHANGE:

  Before:

  ```ts
  const auth = provideGuard(function(http: Http) {

    return function(route: Route, params: any, isTerminal: boolean): Observable<boolean> {
      return http.get('/auth')
        .map(() => true)
        .catch(() => Observable.of(false));
    };

  }, [ Http ]);
  ```

  After:

  ```ts
  @Injectable()
  export class AuthGuard implements Guard {
    constructor(private http: Http) { }

    protectRoute({ route, params, isTerminal }: TraversalCandidate): Observable<boolean> {
      return this.http.get('/auth')
        .map(() => true)
        .catch(() => Observable.of(false));
    }
  }
  ```