### PR TITLE
refactor(routes): Rename `indexRoute` and `loadIndexRoute`

### DIFF
--- a/lib/route-traverser.ts
+++ b/lib/route-traverser.ts
@@ -175,7 +175,7 @@ export class RouteTraverser {
   }
 
   private _loadIndexRoute(route: Route): Promise<Route> {
-    return this._loader.load(route.indexRoute, route.loadIndexRoute, null);
+    return this._loader.load(route.index, route.loadIndex, null);
   }
 }
 

--- a/lib/route.ts
+++ b/lib/route.ts
@@ -23,8 +23,8 @@ export interface IndexRoute extends BaseRoute {
 export interface Route extends IndexRoute {
   path?: string;
   guards?: any[];
-  indexRoute?: IndexRoute;
-  loadIndexRoute?: Async<IndexRoute>;
+  index?: IndexRoute;
+  loadIndex?: Async<IndexRoute>;
   children?: Routes;
   loadChildren?: Async<Routes>;
 }

--- a/spec/route-traverser.spec.ts
+++ b/spec/route-traverser.spec.ts
@@ -33,7 +33,7 @@ describe('RouteTraverser', function() {
       children: [
         UsersRoute = {
           path: 'users',
-          indexRoute: (UsersIndexRoute = {}),
+          index: (UsersIndexRoute = {}),
           children: [
             UserRoute = {
               path: ':userID',
@@ -364,7 +364,7 @@ describe('RouteTraverser', function() {
   describe('asynchronous route config', function() {
     function makeAsyncRouteConfig(routes: Routes) {
       routes.forEach(route => {
-        const { children, indexRoute } = route;
+        const { children, index } = route;
 
         if ( children ) {
           delete route.children;
@@ -374,10 +374,10 @@ describe('RouteTraverser', function() {
           makeAsyncRouteConfig(children);
         }
 
-        if ( indexRoute ) {
-          delete route.indexRoute;
+        if ( index ) {
+          delete route.index;
 
-          route.loadIndexRoute = () => Promise.resolve(indexRoute);
+          route.loadIndex = () => Promise.resolve(index);
         }
       });
     }


### PR DESCRIPTION
BREAKING CHANGE:

  `indexRoute` is now `index` and `loadIndexRoute` is now `loadIndex`

  BEFORE:

  ```ts
  const routes: Routes = [
    {
      path: '/',
      component: MarketingTemplateComponent,
      indexRoute: {
        component: HomePageComponent,
      }
    },
    {
      path: '/blog',
      component: BlogComponent,
      loadIndexRoute: () => System.import('app/routes/blog')
    }
  ];
  ```

  AFTER:

  ```ts
  const routes: Routes = [
    {
      path: '/',
      component: MarketingTemplateComponent,
      index: {
        component: HomePageComponent
      }
    },
    {
      path: '/blog',
      component: BlogComponent,
      loadIndex: () => System.import('app/routes/blog')
    }
  ];
  ```