### PR TITLE
docs(overview): Added docs section for SystemJS configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,4 @@ That's it! You are ready to begin taking advantage of reactive routing!
 * [Code Splitting](./docs/overview/code-splitting.md)
 * [Route and Query Parameters](./docs/overview/params.md)
 * [Guarding Routes](./docs/overview/guards.md)
+* [SystemJS Configuration](./docs/overview/systemjs.md)

--- a/docs/overview/systemjs.md
+++ b/docs/overview/systemjs.md
@@ -1,0 +1,48 @@
+# SystemJS Configuration
+`SystemJS` is a universal dynamic module loader for loading various module formats in the browser and NodeJS. Using `@ngrx/router` with SystemJS as a dynamic module loader requires a bit more setup due to external dependencies.
+
+### Setup
+
+Below is an example of a SystemJS config which maps  `@ngrx/router` to its npm package folder along with its external dependencies including `path-to-regexp`, `isarray`, `query-string` and `strict-uri-encode`. If you have an existing SystemJS config, just add `@ngrx/router` sections to your configuration.
+
+```js
+
+System.config({
+  map: {    
+    // @ngrx/router
+    '@ngrx/router': 'node_modules/@ngrx/router',
+
+    // @ngrx/router dependencies
+    'path-to-regexp': 'node_modules/path-to-regexp',
+    'isarray': 'node_modules/isarray',
+    'query-string': 'node_modules/query-string',
+    'strict-uri-encode': 'node_modules/strict-uri-encode'
+  },
+  //packages defines our app package
+  packages: {    
+    // @ngrx/router package
+    '@ngrx/router': {
+      main: 'index.js',
+      defaultExtension: 'js'
+    },
+
+    // @ngrx/router dependencies
+    'path-to-regexp': {
+      main: 'index.js',
+      defaultExtension: 'js'
+    },  
+    'isarray': {
+      main: 'index.js',
+      defaultExtension: 'js'
+    },  
+    'query-string': {
+      main: 'index.js',
+      defaultExtension: 'js'
+    },  
+    'strict-uri-encode': {
+      main: 'index.js',
+      defaultExtension: 'js'
+    }
+  }
+});
+```


### PR DESCRIPTION
Helps with initial setup for those using SystemJS as a loader instead of using a module bundler.
