### PR TITLE
feat(RouteTraverser): Allow forward slash in nested route paths

### DIFF
--- a/lib/route-traverser.ts
+++ b/lib/route-traverser.ts
@@ -101,12 +101,6 @@ export class RouteTraverser {
   ): Observable<Match> {
     const pattern = route.path || '';
 
-    if ( pattern.charAt(0) === '/' ) {
-      remainingPathname = pathname;
-      paramNames = [];
-      paramValues = [];
-    }
-
     return Observable.of(route)
       .filter(() => remainingPathname !== null)
       .do(() => {
@@ -182,22 +176,3 @@ export class RouteTraverser {
 export const MATCH_ROUTE_PROVIDERS = [
   new Provider(RouteTraverser, { useClass: RouteTraverser })
 ];
-
-
-export function assignParams(paramNames: string[], paramValues: string[]) {
-  return paramNames.reduce(function (params, paramName, index) {
-    const paramValue = paramValues && paramValues[index];
-
-    if ( Array.isArray(params[paramName]) ) {
-      params[paramName].push(paramValue);
-    }
-    else if (paramName in params) {
-      params[paramName] = [ params[paramName], paramValue ];
-    }
-    else {
-      params[paramName] = paramValue;
-    }
-
-    return params;
-  }, {});
-}

--- a/spec/route-traverser.spec.ts
+++ b/spec/route-traverser.spec.ts
@@ -42,7 +42,7 @@ describe('RouteTraverser', function() {
                   path: '/profile'
                 },
                 PostRoute = {
-                  path: ':postID'
+                  path: '/:postID'
                 }
               ]
             },
@@ -66,7 +66,7 @@ describe('RouteTraverser', function() {
       path: '/(optional)?',
       children: [
         OptionalRouteChild = {
-          path: 'child'
+          path: '/child'
         }
       ]
     },
@@ -346,19 +346,6 @@ describe('RouteTraverser', function() {
 
   describe('synchronous route config', function() {
     describeRoutes();
-
-    xdescribe('when the location matches a nested absolute route', function() {
-      it('matches the correct routes', function(done) {
-        traverser
-          .find(change('/team'))
-          .subscribe(match => {
-            expect(match).toBeDefined();
-            expect(match.routes).toEqual([ RootRoute, UsersRoute, TeamRoute ]);
-
-            done();
-          });
-      });
-    });
   });
 
   describe('asynchronous route config', function() {


### PR DESCRIPTION
Before we ignored nested child routes that contained a forward slash at the beginning of the path. This was to potentially allow for absolute path URLs in nested routes, however there is no way to make this feature work with async route configuration. This change removes this restriction and allows you to add a forward slash at the beginning of the path with no functional difference.