### PR TITLE
fix(docs): Use correct method for redirect

### DIFF
--- a/docs/overview/guards.md
+++ b/docs/overview/guards.md
@@ -89,7 +89,7 @@ class AuthGuard implements Guard {
       .map(() => true)
       // If request fails, catch the error and redirect
       .catch(() => {
-        this._router.redirect('/400');
+        this._router.go('/400');
 
         return Observable.of(false);
       });


### PR DESCRIPTION
There is no such method .redirect() on Router. Update to correct one.