### PR TITLE
updated docs to include webpack config

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,4 +111,5 @@ That's it! You are ready to begin taking advantage of reactive routing!
 * [Route and Query Parameters](./docs/overview/params.md)
 * [Guarding Routes](./docs/overview/guards.md)
 * [SystemJS Configuration](./docs/overview/systemjs.md)
+* [Webpack Configuration](./docs/overview/webpack.md)
 * [Angular CLI Configuration](./docs/overview/angular-cli.md)

--- a/docs/overview/webpack.md
+++ b/docs/overview/webpack.md
@@ -1,9 +1,9 @@
 # Webpack Configuration
-`Webpack` takes modules with dependencies and generates static assets representing those modules. Webpack has issues loading `@ngrx/core`, `@ngrx/router`, and `@ngrx/router-store` from the node_modules folder (similar to `@angular`, `rxjs`, and `@angular2-material`), so their source maps need to be excluded from the preLoaders. 
+`Webpack` takes modules with dependencies and generates static assets representing those modules. Webpack has issues loading `@ngrx/router` and `@ngrx/core` from the node_modules folder (similar to `@angular`, `rxjs`, and `@angular2-material`), so their source maps need to be excluded from the preLoaders. 
 
 ### Setup
 
-Below is an example of a Webpack config which maps  `@ngrx/router` to its npm package folder along with its external dependencies including `@ngrx/core` and  `@ngrx/router-store`. If you have an existing Webpack config, just add the following sections to your configuration (`config/webpack.common.js` in the [Angular 2 Webpack Starter](https://github.com/AngularClass/angular2-webpack-starter)).
+Below is an example of a Webpack config which maps  `@ngrx/router` to its npm package folder along with `@ngrx/core`, an external dependency. If you have an existing Webpack config, just add the following sections to your configuration (`config/webpack.common.js` in the [Angular 2 Webpack Starter](https://github.com/AngularClass/angular2-webpack-starter)).
 
 ```js
 
@@ -19,10 +19,13 @@ module.exports = {
       exclude: [
         // these packages have problems with their sourcemaps
         helpers.root('node_modules/@ngrx/core'),
-        helpers.root('node_modules/@ngrx/router'),
-        helpers.root('node_modules/@ngrx/router-store')
+        helpers.root('node_modules/@ngrx/router')
       ]
     }
    ]
+  }
+  
+ ...
+ 
 };
 ```

--- a/docs/overview/webpack.md
+++ b/docs/overview/webpack.md
@@ -1,0 +1,28 @@
+# Webpack Configuration
+`Webpack` takes modules with dependencies and generates static assets representing those modules. Webpack has issues loading `@ngrx/core`, `@ngrx/router`, and `@ngrx/router-store` from the node_modules folder (similar to `@angular`, `rxjs`, and `@angular2-material`), so their source maps need to be excluded from the preLoaders. 
+
+### Setup
+
+Below is an example of a Webpack config which maps  `@ngrx/router` to its npm package folder along with its external dependencies including `@ngrx/core` and  `@ngrx/router-store`. If you have an existing Webpack config, just add the following sections to your configuration (`config/webpack.common.js` in the [Angular 2 Webpack Starter](https://github.com/AngularClass/angular2-webpack-starter)).
+
+```js
+
+module.exports = {
+  
+  ...
+  
+  module: {
+    preLoaders: [
+    {
+      test: /\.js$/,
+      loader: 'source-map-loader',
+      exclude: [
+        // these packages have problems with their sourcemaps
+        helpers.root('node_modules/@ngrx/core'),
+        helpers.root('node_modules/@ngrx/router'),
+        helpers.root('node_modules/@ngrx/router-store')
+      ]
+    }
+   ]
+};
+```


### PR DESCRIPTION
Was getting errors like this when trying to integrate with the Angular 2 Webpack Starter:

WARNING in ./~/@ngrx/router/index.js
Cannot find source file '../../lib/index.ts': Error: Cannot resolve 'file' or 'directory' ../../lib/index.ts in /home/select/Dev/shoutr-srv/client/node_modules/@ngrx/router

Found the solution on gitter here: https://gitter.im/ngrx/store/archives/2016/04/26, and thought I should share with everyone else.
