### PR TITLE
Updating links to angular documentation

### DIFF
--- a/docs/overview/location-strategy.md
+++ b/docs/overview/location-strategy.md
@@ -1,8 +1,8 @@
 # Location Strategy
 
 Angular 2 supports two kinds of routing known as location strategies.
-- [PathLocationStrategy](https://angular.io/docs/js/latest/api/router/PathLocationStrategy-class.html)
-- [HashLocationStrategy](https://angular.io/docs/js/latest/api/router/HashLocationStrategy-class.html)
+- [PathLocationStrategy](https://angular.io/docs/ts/latest/api/common/index/PathLocationStrategy-class.html)
+- [HashLocationStrategy](https://angular.io/docs/ts/latest/api/common/index/HashLocationStrategy-class.html)
 
 
 The location strategy can be registered with ngrx/router during bootstrap, and if not specified explicitly, it will default to PathLocationStrategy.


### PR DESCRIPTION
Links were pointing to a 404 page because those pages have been moved.